### PR TITLE
Aligner le front du Parcours 1 sur les maquettes Notion-like

### DIFF
--- a/comptes/forms.py
+++ b/comptes/forms.py
@@ -22,10 +22,10 @@ class EmailAuthenticationForm(AuthenticationForm):
 
     error_messages = {
         "invalid_login": _(
-            "Identifiants invalides. Vérifie ton adresse e-mail et ton mot de passe."
+            "Identifiants invalides. Vérifiez votre adresse e-mail et votre mot de passe."
         ),
         "inactive": _(
-            "Identifiants invalides. Vérifie ton adresse e-mail et ton mot de passe."
+            "Identifiants invalides. Vérifiez votre adresse e-mail et votre mot de passe."
         ),
     }
 

--- a/comptes/templates/comptes/login.html
+++ b/comptes/templates/comptes/login.html
@@ -1,52 +1,59 @@
 {% extends "base.html" %}
-{% load static %}
 
 {% block title %}Connexion — HomeSweetHome{% endblock %}
 
 {% block content %}
 <div class="public-page">
     <nav class="public-nav">
-        <div class="logo-mark">HSH</div>
-        <span class="muted sm">HomeSweetHome</span>
+        <div class="sb-brand-mark">HSH</div>
+        <span class="sb-brand-name">HomeSweetHome</span>
     </nav>
 
     <div class="public-body">
-        <section>
+        <section class="public-left">
+            <div class="muted sm">HomeSweetHome</div>
             <h1 class="hero-title">Une charge ménagère partagée, sans charge mentale.</h1>
             <p class="hero-lead">
-                Connecte-toi pour retrouver ton foyer, suivre les activités du quotidien
-                et répartir équitablement la charge avec ton conjoint.
+                Connectez-vous pour retrouver votre foyer, suivre les activités du quotidien
+                et répartir équitablement la charge avec votre conjoint·e.
             </p>
         </section>
 
-        <section class="form-card">
-            <h2 class="form-title">Connexion</h2>
+        <section class="public-right">
+            <div class="form-card">
+                <h2 class="form-title">Connexion</h2>
 
-            {% if form.non_field_errors %}
-            <div class="banner" role="alert">
-                <span>{{ form.non_field_errors|join:" " }}</span>
+                {% if form.non_field_errors %}
+                <div class="banner" role="alert">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                         stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <circle cx="12" cy="12" r="9"/>
+                        <path d="M12 8v.01M12 11v5"/>
+                    </svg>
+                    <span>{{ form.non_field_errors|join:" " }}</span>
+                </div>
+                {% endif %}
+
+                <form method="post" novalidate>
+                    {% csrf_token %}
+
+                    <div class="field">
+                        <label for="{{ form.username.id_for_label }}" class="field-label">
+                            {{ form.username.label }}
+                        </label>
+                        {{ form.username }}
+                    </div>
+
+                    <div class="field">
+                        <label for="{{ form.password.id_for_label }}" class="field-label">
+                            {{ form.password.label }}
+                        </label>
+                        {{ form.password }}
+                    </div>
+
+                    <button type="submit" class="btn btn-primary btn-full">Se connecter</button>
+                </form>
             </div>
-            {% endif %}
-
-            <form method="post" novalidate>
-                {% csrf_token %}
-
-                <div class="field">
-                    <label for="{{ form.username.id_for_label }}" class="field-label">
-                        {{ form.username.label }}
-                    </label>
-                    {{ form.username }}
-                </div>
-
-                <div class="field">
-                    <label for="{{ form.password.id_for_label }}" class="field-label">
-                        {{ form.password.label }}
-                    </label>
-                    {{ form.password }}
-                </div>
-
-                <button type="submit" class="btn btn-primary btn-full">Se connecter</button>
-            </form>
         </section>
     </div>
 </div>

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -73,6 +73,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "foyer.context_processors.foyer_courant",
             ],
         },
     },

--- a/foyer/context_processors.py
+++ b/foyer/context_processors.py
@@ -1,0 +1,22 @@
+"""Contexts globaux du domaine ``foyer``."""
+from __future__ import annotations
+
+from .models import MembreFoyer
+
+
+def foyer_courant(request):
+    """Expose le foyer de l'utilisateur connecté à tous les templates.
+
+    Permet aux layouts partagés (sidebar, top bar) d'afficher le nom du foyer
+    sans que chaque vue n'ait à le réinjecter dans son contexte.
+    """
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated:
+        return {"foyer_courant": None}
+
+    membre = (
+        MembreFoyer.objects.select_related("foyer")
+        .filter(user=user)
+        .first()
+    )
+    return {"foyer_courant": membre.foyer if membre else None}

--- a/foyer/forms.py
+++ b/foyer/forms.py
@@ -31,7 +31,7 @@ class InvitationCreationForm(forms.Form):
 
 class AccepterInvitationNouveauCompteForm(forms.Form):
     password = forms.CharField(
-        label="Choisis un mot de passe",
+        label="Mot de passe",
         strip=False,
         widget=forms.PasswordInput(attrs={
             "autocomplete": "new-password",
@@ -39,7 +39,7 @@ class AccepterInvitationNouveauCompteForm(forms.Form):
         }),
     )
     password_confirm = forms.CharField(
-        label="Confirme le mot de passe",
+        label="Confirmer le mot de passe",
         strip=False,
         widget=forms.PasswordInput(attrs={
             "autocomplete": "new-password",

--- a/foyer/templates/foyer/_invitation_form.html
+++ b/foyer/templates/foyer/_invitation_form.html
@@ -1,9 +1,38 @@
 <div class="card" id="invitation-form-card">
     <div class="card-title">Inviter un membre</div>
-    <p class="muted sm">
-        Génère un lien d'invitation à transmettre à la personne par le canal de ton choix
-        (SMS, messagerie...).
-    </p>
+    <p class="muted sm">Choisissez comment partager l'accès au foyer.</p>
+
+    <div class="choice" aria-disabled="true" title="Bientôt disponible">
+        <div class="choice-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="5" width="18" height="14" rx="2"/>
+                <path d="M3 7l9 6 9-6"/>
+            </svg>
+        </div>
+        <div class="choice-grow">
+            <div class="choice-title">Par e-mail</div>
+            <div class="muted sm">Envoi automatique d'un lien à son adresse</div>
+        </div>
+        <span class="tag">Bientôt</span>
+    </div>
+
+    <div class="choice selected">
+        <div class="choice-icon">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M10 14a4 4 0 0 0 5.6 0l3-3a4 4 0 0 0-5.6-5.6l-1 1"/>
+                <path d="M14 10a4 4 0 0 0-5.6 0l-3 3a4 4 0 1 0 5.6 5.6l1-1"/>
+            </svg>
+        </div>
+        <div class="choice-grow">
+            <div class="choice-title">Lien d'invitation</div>
+            <div class="muted sm">Génère un lien à partager (SMS, messagerie…)</div>
+        </div>
+        <div class="radio on" aria-hidden="true"></div>
+    </div>
+
+    <div class="divider"></div>
 
     <form method="post"
           action="{% url 'foyer:invitation-create' %}"
@@ -38,7 +67,7 @@
         </div>
 
         <div class="btn-row end">
-            <button type="submit" class="btn btn-primary btn-sm">Générer le lien</button>
+            <button type="submit" class="btn btn-primary">Générer le lien</button>
         </div>
     </form>
 </div>

--- a/foyer/templates/foyer/_invitation_lien.html
+++ b/foyer/templates/foyer/_invitation_lien.html
@@ -3,13 +3,20 @@
     <div class="card-title">Une invitation est déjà en cours</div>
     <p class="muted sm">
         Une invitation pour <strong>{{ invitation.email }}</strong> existe déjà.
-        Copie le lien ci-dessous pour la relancer, ou annule-la dans la liste plus bas.
+        Copiez le lien ci-dessous pour la relancer, ou annulez-la dans la liste plus haut.
     </p>
     {% else %}
+    <div class="success-banner" role="status">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+             stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M5 12l5 5L20 7"/>
+        </svg>
+        <span>Invitation créée pour {{ invitation.prenom }}.</span>
+    </div>
     <div class="card-title">Lien d'invitation pour {{ invitation.prenom }}</div>
     <p class="muted sm">
-        Transmets ce lien à <strong>{{ invitation.email }}</strong> par le canal de
-        ton choix. Il expire le {{ invitation.date_expiration|date:"j F Y" }}.
+        Transmettez ce lien à <strong>{{ invitation.email }}</strong> par le canal de votre choix.
+        Il expire le {{ invitation.date_expiration|date:"j F Y" }}.
     </p>
     {% endif %}
 

--- a/foyer/templates/foyer/_invitation_liste.html
+++ b/foyer/templates/foyer/_invitation_liste.html
@@ -1,3 +1,4 @@
+{% load foyer_tags %}
 <div id="invitations-en-attente"
      hx-get="{% url 'foyer:invitation-liste' %}"
      hx-trigger="invitations-mises-a-jour from:body"
@@ -6,6 +7,7 @@
         {% for invitation in invitations_en_attente %}
         <div class="card pending">
             <div class="card-row">
+                <div class="avatar avatar-empty">{{ invitation.prenom|initiale }}</div>
                 <div class="card-grow">
                     <div class="card-title">{{ invitation.prenom }}</div>
                     <div class="muted sm">
@@ -34,7 +36,5 @@
             </div>
         </div>
         {% endfor %}
-    {% else %}
-        <div class="muted sm">Aucune invitation en attente.</div>
     {% endif %}
 </div>

--- a/foyer/templates/foyer/accepter_invitation.html
+++ b/foyer/templates/foyer/accepter_invitation.html
@@ -1,112 +1,154 @@
 {% extends "base.html" %}
+{% load foyer_tags %}
 
 {% block title %}Rejoindre {{ invitation.foyer.nom }} — HomeSweetHome{% endblock %}
 
 {% block content %}
 <div class="public-page">
     <nav class="public-nav">
-        <div class="logo-mark">HSH</div>
-        <span class="muted sm">HomeSweetHome</span>
+        <div class="sb-brand-mark">HSH</div>
+        <span class="sb-brand-name">HomeSweetHome</span>
     </nav>
 
     <div class="public-body">
-        <section>
+        <section class="public-left">
+            <div class="muted sm">Vous avez été invité·e</div>
             <h1 class="hero-title">
-                Tu es invité·e à rejoindre <em>{{ invitation.foyer.nom }}</em>.
+                {{ invitation.foyer.cree_par.first_name|default:invitation.foyer.cree_par.email }}
+                vous invite à rejoindre <em>« {{ invitation.foyer.nom }} »</em>
             </h1>
             <p class="hero-lead">
-                {{ invitation.foyer.cree_par.first_name|default:invitation.foyer.cree_par.email }}
-                t'a invité·e à partager la gestion des tâches du foyer sur HomeSweetHome.
+                Organisez la répartition des charges du foyer ensemble, en tenant compte
+                de la charge physique et mentale de chaque tâche.
             </p>
+            <div class="card minimal">
+                <div class="card-row">
+                    <div class="avatar">
+                        {{ invitation.foyer.cree_par.first_name|default:invitation.foyer.cree_par.email|initiale }}
+                    </div>
+                    <div class="card-grow">
+                        <div class="card-title">
+                            {{ invitation.foyer.cree_par.first_name|default:invitation.foyer.cree_par.email }}
+                        </div>
+                        <div class="muted sm">{{ invitation.foyer.cree_par.email }}</div>
+                    </div>
+                </div>
+            </div>
         </section>
 
-        <section class="form-card">
-            <h2 class="form-title">Bienvenue {{ invitation.prenom }} !</h2>
+        <section class="public-right">
+            <div class="form-card">
+                {% if scenario == "nouveau" %}
+                <div class="stepper">
+                    <div class="step step-current">
+                        <span class="step-num">1</span>
+                        <span class="step-label">Compte</span>
+                    </div>
+                    <span class="step-line"></span>
+                    <div class="step">
+                        <span class="step-num">2</span>
+                        <span class="step-label">Foyer</span>
+                    </div>
+                </div>
+                {% endif %}
 
-            {% if erreur %}
-            <div class="banner" role="alert">
-                <span>{{ erreur }}</span>
+                <h2 class="form-title">Bienvenue {{ invitation.prenom }} !</h2>
+
+                {% if erreur %}
+                <div class="banner" role="alert">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                         stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <circle cx="12" cy="12" r="9"/>
+                        <path d="M12 8v.01M12 11v5"/>
+                    </svg>
+                    <span>{{ erreur }}</span>
+                </div>
+                {% endif %}
+
+                {% if scenario == "nouveau" %}
+                    <p class="muted sm">
+                        Choisissez un mot de passe pour finaliser la création de votre compte
+                        ({{ invitation.email }}) et rejoindre le foyer.
+                    </p>
+
+                    <form method="post" novalidate>
+                        {% csrf_token %}
+
+                        {% if password_form.non_field_errors %}
+                        <div class="banner" role="alert">
+                            <span>{{ password_form.non_field_errors|join:" " }}</span>
+                        </div>
+                        {% endif %}
+
+                        <div class="field">
+                            <label for="{{ password_form.password.id_for_label }}" class="field-label">
+                                {{ password_form.password.label }}
+                            </label>
+                            {{ password_form.password }}
+                            {% if password_form.password.errors %}
+                            <div class="field-hint" style="color: var(--accent);">
+                                {{ password_form.password.errors|join:" " }}
+                            </div>
+                            {% else %}
+                            <span class="field-hint">8 caractères minimum.</span>
+                            {% endif %}
+                        </div>
+
+                        <div class="field">
+                            <label for="{{ password_form.password_confirm.id_for_label }}" class="field-label">
+                                {{ password_form.password_confirm.label }}
+                            </label>
+                            {{ password_form.password_confirm }}
+                            {% if password_form.password_confirm.errors %}
+                            <div class="field-hint" style="color: var(--accent);">
+                                {{ password_form.password_confirm.errors|join:" " }}
+                            </div>
+                            {% endif %}
+                        </div>
+
+                        <button type="submit" class="btn btn-primary btn-full">
+                            Accepter et rejoindre le foyer
+                        </button>
+                        <p class="muted sm center" style="margin-top: 8px;">
+                            En continuant, vous acceptez les CGU.
+                        </p>
+                    </form>
+
+                {% elif scenario == "user_existant_connecte" %}
+                    <p class="muted sm">
+                        Vous êtes connecté·e en tant que <strong>{{ request.user.email }}</strong>.
+                        Confirmez pour rejoindre le foyer.
+                    </p>
+                    <form method="post" novalidate>
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-primary btn-full">
+                            Rejoindre le foyer
+                        </button>
+                    </form>
+
+                {% elif scenario == "user_existant_non_connecte" %}
+                    <p class="muted sm">
+                        Un compte existe déjà pour <strong>{{ invitation.email }}</strong>.
+                        Connectez-vous pour accepter l'invitation.
+                    </p>
+                    <a href="{{ login_url }}" class="btn btn-primary btn-full">
+                        Se connecter
+                    </a>
+
+                {% elif scenario == "user_existant_mauvais_compte" %}
+                    <p class="muted sm">
+                        Vous êtes connecté·e en tant que <strong>{{ request.user.email }}</strong>,
+                        mais cette invitation est destinée à <strong>{{ invitation.email }}</strong>.
+                        Déconnectez-vous puis suivez à nouveau le lien d'invitation.
+                    </p>
+                    <form method="post" action="{% url 'comptes:deconnexion' %}">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-primary btn-full">
+                            Se déconnecter
+                        </button>
+                    </form>
+                {% endif %}
             </div>
-            {% endif %}
-
-            {% if scenario == "nouveau" %}
-                <p class="muted sm">
-                    Choisis un mot de passe pour finaliser la création de ton compte
-                    ({{ invitation.email }}) et rejoindre le foyer.
-                </p>
-
-                <form method="post" novalidate>
-                    {% csrf_token %}
-
-                    {% if password_form.non_field_errors %}
-                    <div class="banner" role="alert">
-                        <span>{{ password_form.non_field_errors|join:" " }}</span>
-                    </div>
-                    {% endif %}
-
-                    <div class="field">
-                        <label for="{{ password_form.password.id_for_label }}" class="field-label">
-                            {{ password_form.password.label }}
-                        </label>
-                        {{ password_form.password }}
-                        {% if password_form.password.errors %}
-                        <div class="field-hint" style="color: var(--accent);">
-                            {{ password_form.password.errors|join:" " }}
-                        </div>
-                        {% endif %}
-                    </div>
-
-                    <div class="field">
-                        <label for="{{ password_form.password_confirm.id_for_label }}" class="field-label">
-                            {{ password_form.password_confirm.label }}
-                        </label>
-                        {{ password_form.password_confirm }}
-                        {% if password_form.password_confirm.errors %}
-                        <div class="field-hint" style="color: var(--accent);">
-                            {{ password_form.password_confirm.errors|join:" " }}
-                        </div>
-                        {% endif %}
-                    </div>
-
-                    <button type="submit" class="btn btn-primary btn-full">
-                        Rejoindre le foyer
-                    </button>
-                </form>
-
-            {% elif scenario == "user_existant_connecte" %}
-                <p class="muted sm">
-                    Tu es connecté·e en tant que <strong>{{ request.user.email }}</strong>.
-                    Confirme pour rejoindre le foyer.
-                </p>
-                <form method="post" novalidate>
-                    {% csrf_token %}
-                    <button type="submit" class="btn btn-primary btn-full">
-                        Rejoindre le foyer
-                    </button>
-                </form>
-
-            {% elif scenario == "user_existant_non_connecte" %}
-                <p class="muted sm">
-                    Un compte existe déjà pour <strong>{{ invitation.email }}</strong>.
-                    Connecte-toi pour accepter l'invitation.
-                </p>
-                <a href="{{ login_url }}" class="btn btn-primary btn-full">
-                    Se connecter
-                </a>
-
-            {% elif scenario == "user_existant_mauvais_compte" %}
-                <p class="muted sm">
-                    Tu es connecté·e en tant que <strong>{{ request.user.email }}</strong>,
-                    mais cette invitation est destinée à <strong>{{ invitation.email }}</strong>.
-                    Déconnecte-toi puis suis à nouveau le lien d'invitation.
-                </p>
-                <form method="post" action="{% url 'comptes:deconnexion' %}">
-                    {% csrf_token %}
-                    <button type="submit" class="btn btn-primary btn-full">
-                        Se déconnecter
-                    </button>
-                </form>
-            {% endif %}
         </section>
     </div>
 </div>

--- a/foyer/templates/foyer/invitation_invalide.html
+++ b/foyer/templates/foyer/invitation_invalide.html
@@ -5,27 +5,30 @@
 {% block content %}
 <div class="public-page">
     <nav class="public-nav">
-        <div class="logo-mark">HSH</div>
-        <span class="muted sm">HomeSweetHome</span>
+        <div class="sb-brand-mark">HSH</div>
+        <span class="sb-brand-name">HomeSweetHome</span>
     </nav>
 
     <div class="public-body">
-        <section>
+        <section class="public-left">
+            <div class="muted sm">Invitation introuvable</div>
             <h1 class="hero-title">Ce lien d'invitation n'est plus valide.</h1>
             <p class="hero-lead">
                 Le lien a peut-être expiré, été annulé, ou déjà utilisé.
-                Demande à la personne qui t'a invité·e d'en générer un nouveau.
+                Demandez à la personne qui vous a invité·e d'en générer un nouveau.
             </p>
         </section>
 
-        <section class="form-card">
-            <h2 class="form-title">Tu as déjà un compte ?</h2>
-            <p class="muted sm">
-                Si tu es déjà membre d'un foyer, connecte-toi pour le retrouver.
-            </p>
-            <a href="{% url 'comptes:connexion' %}" class="btn btn-primary btn-full">
-                Se connecter
-            </a>
+        <section class="public-right">
+            <div class="form-card">
+                <h2 class="form-title">Vous avez déjà un compte ?</h2>
+                <p class="muted sm">
+                    Si vous êtes déjà membre d'un foyer, connectez-vous pour le retrouver.
+                </p>
+                <a href="{% url 'comptes:connexion' %}" class="btn btn-primary btn-full">
+                    Se connecter
+                </a>
+            </div>
         </section>
     </div>
 </div>

--- a/foyer/templates/foyer/mon_foyer.html
+++ b/foyer/templates/foyer/mon_foyer.html
@@ -1,13 +1,32 @@
-{% extends "base.html" %}
+{% extends "app_base.html" %}
+{% load foyer_tags %}
 
 {% block title %}{{ foyer.nom }} — HomeSweetHome{% endblock %}
 
-{% block content %}
-<div class="centered-page">
+{% block app_content %}
+<div class="content-medium">
+    {% for message in messages %}
+        {% if message.tags == 'success' %}
+        <div class="success-banner" role="status">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M5 12l5 5L20 7"/>
+            </svg>
+            <span>{{ message }}</span>
+        </div>
+        {% endif %}
+    {% endfor %}
+
     <header class="page-head">
         <div>
-            <h1 class="page-title">{{ foyer.nom }}</h1>
-            <p class="muted sm">Créé le {{ foyer.date_creation|date:"j F Y" }}</p>
+            <h1 class="page-title">Membres</h1>
+            <p class="muted">
+                {{ foyer.nom }} ·
+                {{ membres|length }} membre{{ membres|length|pluralize }}
+                {% if invitations_en_attente %}
+                · {{ invitations_en_attente|length }} en attente
+                {% endif %}
+            </p>
         </div>
         <form method="post" action="{% url 'comptes:deconnexion' %}">
             {% csrf_token %}
@@ -16,31 +35,61 @@
     </header>
 
     <section>
-        <div class="cat-head">Membres du foyer</div>
         {% for membre in membres %}
         <div class="card">
             <div class="card-row">
-                <div class="card-grow">
-                    <div class="card-title">{{ membre.user.email }}</div>
-                    <div class="muted sm">Membre depuis le {{ membre.date_arrivee|date:"j F Y" }}</div>
+                <div class="avatar {% if membre.user_id != foyer.cree_par_id %}avatar-2{% endif %}">
+                    {{ membre.user.first_name|default:membre.user.email|initiale }}
                 </div>
+                <div class="card-grow">
+                    <div class="card-title">
+                        {{ membre.user.first_name|default:membre.user.email }}
+                        {% if membre.user.first_name %}
+                        <span class="muted sm">· {{ membre.user.email }}</span>
+                        {% endif %}
+                    </div>
+                    <div class="muted sm">
+                        {% if membre.user_id == foyer.cree_par_id %}Administrateur{% else %}Membre{% endif %}
+                        · Membre depuis le {{ membre.date_arrivee|date:"j F Y" }}
+                    </div>
+                </div>
+                {% if membre.user_id == request.user.pk %}
+                <span class="tag">Vous</span>
+                {% endif %}
             </div>
         </div>
         {% endfor %}
+
+        {% if est_createur %}
+            {% include "foyer/_invitation_liste.html" %}
+        {% endif %}
     </section>
 
     {% if est_createur %}
-    <section>
-        <div class="cat-head">Inviter un membre</div>
-        <div id="invitation-form-zone">
-            {% include "foyer/_invitation_form.html" %}
+        {% if membres|length == 1 and not invitations_en_attente %}
+        <div class="empty">
+            <div class="empty-illu" aria-hidden="true"></div>
+            <div class="empty-title">Vous êtes seul·e ici</div>
+            <div class="empty-sub">
+                Invitez votre conjoint·e pour commencer à répartir les tâches du foyer.
+            </div>
         </div>
-    </section>
+        {% endif %}
 
-    <section>
-        <div class="cat-head">Invitations en attente</div>
-        {% include "foyer/_invitation_liste.html" %}
-    </section>
+        <section style="margin-top: 24px;">
+            <div class="cat-head">Inviter un membre</div>
+            <div id="invitation-form-zone">
+                {% include "foyer/_invitation_form.html" %}
+            </div>
+        </section>
+
+        {% if membres|length >= 2 %}
+        <div class="next-step">
+            <div class="muted sm">Prochaine étape</div>
+            <div class="card-title">Lister ensemble vos activités</div>
+            <p class="muted sm">Bientôt disponible — vous pourrez recenser les tâches du foyer.</p>
+        </div>
+        {% endif %}
     {% endif %}
 </div>
 {% endblock %}

--- a/foyer/templatetags/foyer_tags.py
+++ b/foyer/templatetags/foyer_tags.py
@@ -1,0 +1,15 @@
+"""Template tags & filters utilitaires pour le rendu du domaine ``foyer``."""
+from __future__ import annotations
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def initiale(value) -> str:
+    """Retourne la 1re lettre de ``value`` en majuscule, ``?`` si vide."""
+    if not value:
+        return "?"
+    text = str(value).strip()
+    return text[0].upper() if text else "?"

--- a/foyer/tests/test_views.py
+++ b/foyer/tests/test_views.py
@@ -64,7 +64,7 @@ def test_mon_foyer_affiche_section_invitation_pour_le_createur():
 
     content = response.content.decode("utf-8")
     assert "Inviter un membre" in content
-    assert "Invitations en attente" in content
+    assert "Générer le lien" in content
 
 
 def test_mon_foyer_n_affiche_pas_section_invitation_pour_un_membre_non_createur():
@@ -77,7 +77,7 @@ def test_mon_foyer_n_affiche_pas_section_invitation_pour_un_membre_non_createur(
 
     content = response.content.decode("utf-8")
     assert "Inviter un membre" not in content
-    assert "Invitations en attente" not in content
+    assert "Générer le lien" not in content
 
 
 def test_mon_foyer_liste_les_invitations_en_attente():
@@ -421,8 +421,8 @@ def test_accepter_get_scenario_nouveau_affiche_form_creation_password():
     content = response.content.decode("utf-8")
     assert response.status_code == 200
     assert "Bienvenue Marie" in content
-    assert "Choisis un mot de passe" in content
-    assert "Confirme le mot de passe" in content
+    assert "Mot de passe" in content
+    assert "Confirmer le mot de passe" in content
 
 
 def test_accepter_get_scenario_user_existant_non_connecte_propose_login():
@@ -450,8 +450,8 @@ def test_accepter_get_scenario_user_existant_connecte_affiche_confirmation():
     )
 
     content = response.content.decode("utf-8")
-    assert "Confirme pour rejoindre" in content
-    assert "Choisis un mot de passe" not in content
+    assert "Confirmez pour rejoindre" in content
+    assert "Confirmer le mot de passe" not in content
 
 
 def test_accepter_get_scenario_user_existant_mauvais_compte_propose_logout():
@@ -465,7 +465,7 @@ def test_accepter_get_scenario_user_existant_mauvais_compte_propose_logout():
     )
 
     content = response.content.decode("utf-8")
-    assert "Déconnecte-toi" in content
+    assert "Déconnectez-vous" in content
 
 
 # ---------------------------------------------------------------------------

--- a/foyer/views.py
+++ b/foyer/views.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.contrib.auth import get_user_model, login
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponseForbidden
@@ -43,6 +44,7 @@ class MonFoyerView(LoginRequiredMixin, TemplateView):
         context["foyer"] = foyer
         context["membres"] = foyer.membres.select_related("user").all()
         context["est_createur"] = est_createur
+        context["active_nav"] = "membres"
         if est_createur:
             context["invitation_form"] = InvitationCreationForm()
             context["invitations_en_attente"] = self._invitations_en_attente(foyer)
@@ -231,6 +233,10 @@ class AccepterInvitationView(View):
                     self._contexte_acceptation(request, invitation, erreur=str(exc)),
                     status=400,
                 )
+            messages.success(
+                request,
+                f"Bienvenue dans le foyer « {invitation.foyer.nom} ».",
+            )
             return redirect(self.success_url)
 
         if scenario == "user_existant_non_connecte":
@@ -269,6 +275,10 @@ class AccepterInvitationView(View):
             )
 
         login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+        messages.success(
+            request,
+            f"Bienvenue dans le foyer « {invitation.foyer.nom} ».",
+        )
         return redirect(self.success_url)
 
     @staticmethod

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -27,12 +27,52 @@ html, body {
   font-family: var(--font);
   font-size: 14px;
   color: var(--ink);
-  background: #f4f4f2;
+  background: var(--bg);
   -webkit-font-smoothing: antialiased;
   letter-spacing: -0.005em;
 }
 
-#root { height: 100vh; }
+body { min-height: 100vh; }
+
+/* ── App shell (sidebar + main content) ─── */
+.app-shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+}
+.app-shell .sidebar {
+  border-right: 1px solid var(--line);
+  padding: 18px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.app-shell .sb-item {
+  cursor: pointer;
+  text-decoration: none;
+}
+.app-shell .sb-main {
+  padding: 32px 48px;
+  background: var(--bg);
+  overflow: hidden;
+}
+.app-shell .sb-main > .content-medium,
+.app-shell .sb-main > .content-narrow { margin: 0 auto; }
+
+@media (max-width: 720px) {
+  .app-shell { grid-template-columns: 1fr; }
+  .app-shell .sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    overflow-x: auto;
+  }
+  .app-shell .sidebar .sb-brand { border-bottom: 0; padding: 4px 10px; margin: 0; }
+  .app-shell .sidebar .sb-section { display: none; }
+  .app-shell .sb-main { padding: 24px 20px; }
+}
 
 /* ── Frame chrome (browser-window-lite per screen) ───── */
 .frame {

--- a/templates/app_base.html
+++ b/templates/app_base.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% comment %}
+Layout app HomeSweetHome — sidebar fixe à gauche (logo + nom du foyer en haut,
+puis les sections de navigation). Pour le moment, seul l'item « Membres »
+est affiché ; les autres parcours seront ajoutés au fur et à mesure.
+{% endcomment %}
+
+{% block content %}
+<div class="app-shell">
+    <aside class="sidebar">
+        <div class="sb-brand">
+            <div class="sb-brand-mark">HSH</div>
+            <div class="sb-brand-name">{{ foyer_courant.nom|default:"HomeSweetHome" }}</div>
+        </div>
+
+        <div class="sb-section">Foyer</div>
+        <a class="sb-item {% if active_nav == 'membres' %}active{% endif %}"
+           href="{% url 'foyer:mon-foyer' %}">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="9" cy="8" r="3.5"/>
+                <path d="M2.5 20c0-3.5 3-6 6.5-6s6.5 2.5 6.5 6"/>
+                <path d="M16 4a3.5 3.5 0 0 1 0 7M22 20c0-3-2-5-5-5.5"/>
+            </svg>
+            Membres
+        </a>
+    </aside>
+
+    <main class="sb-main">
+        {% block app_content %}{% endblock %}
+    </main>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Nouveau layout app `templates/app_base.html` : sidebar avec **uniquement** le menu « Membres » + nom du foyer en haut (alimenté par un context processor `foyer.context_processors.foyer_courant`).
- Réécrit les écrans du **Parcours 1** pour matcher les maquettes du bundle design (P1.1 → P1.5) : page-head + cards membre, cards d'invitations en attente, empty state, success-banner, stepper côté acceptation, choix e-mail / lien (e-mail marqué « Bientôt »).
- Harmonise la tonalité des copies en **vouvoiement**, conformément aux maquettes (forms `comptes` et `foyer` inclus).
- Adapte les tests existants à la nouvelle copie ; ajoute le filtre template `initiale` pour les avatars.

## Test plan
- [x] `pytest` (118 tests passent, couverture 96.67 %)
- [x] `ruff check .` (clean)
- [ ] Vérification visuelle locale du parcours :
  - [ ] `/connexion/` (Hero + form-card)
  - [ ] `/foyer/` seul·e (empty state P1.1)
  - [ ] Création d'une invitation → card lien + success-banner
  - [ ] Ouverture du lien dans une fenêtre privée → page d'acceptation P1.4 (stepper)
  - [ ] Création de compte → redirection sur `/foyer/` avec success-banner P1.5
  - [ ] Vérifier le rendu responsive (sidebar repliée < 720 px)

## Notes pour le reviewer
- Le menu de gauche ne contient volontairement que **Membres** pour le moment ; les autres parcours seront ajoutés au fur et à mesure.
- L'option « Par e-mail » du formulaire d'invitation est affichée mais marquée « Bientôt » : le backend ne sait toujours générer qu'un lien (US-103), la maquette est anticipée.
- Une issue de suivi sera ouverte pour la migration vers Tailwind CSS (discutée pendant la session, reportée à un PR dédié).

🤖 Generated with [Claude Code](https://claude.com/claude-code)