### PR TITLE
Skill implement-github-issue : plan interne sans validation

### DIFF
--- a/.claude/skills/implement-github-issue/SKILL.md
+++ b/.claude/skills/implement-github-issue/SKILL.md
@@ -72,9 +72,11 @@ Before planning, explore the codebase:
 3. Identify tests that cover the affected area.
 4. Note any project conventions (CLAUDE.md, CONTRIBUTING.md, lint config, commit style).
 
-### 3. Plan and confirm
+### 3. Plan internally
 
-Produce a **short, concrete plan** and share it with the user before coding:
+Form a **short, concrete plan** to guide implementation — keep it internal, do **not** pause to request the user's approval. Once Phase 1 (load issue) and Phase 2 (understand code) are done, move straight to Phase 4 and start coding.
+
+The plan should still cover, in your head or via `TodoWrite`:
 
 - Files to create/modify (with paths).
 - High-level approach per file.
@@ -82,7 +84,13 @@ Produce a **short, concrete plan** and share it with the user before coding:
 - Risks / open questions.
 - Commands to verify locally (build, test, lint).
 
-**Wait for explicit user approval** unless the issue is trivial (typo, one-line fix) and the user asked to proceed autonomously. See `references/workflow.md` for edge cases.
+**Only pause and confirm with the user** if the plan surfaces real ambiguity that the issue alone can't resolve:
+
+- Contradictory acceptance criteria.
+- Scope clearly larger than what the issue describes.
+- Irreversible or high-blast-radius decisions (data migration, breaking API change, deletion of existing behavior).
+
+See `references/workflow.md` for edge cases.
 
 ### 4. Prepare the branch
 

--- a/.claude/skills/implement-github-issue/references/workflow.md
+++ b/.claude/skills/implement-github-issue/references/workflow.md
@@ -6,7 +6,7 @@ This document covers situations the main `SKILL.md` workflow does not handle dir
 
 If the issue is a typo, a comment fix, or a clearly-scoped one-line change:
 
-- Skip the explicit plan-approval step.
+- Skip even the brief internal planning notes — go straight from issue → branch → fix.
 - Still load the issue, open a branch, open a PR linking the issue.
 - Keep the commit message and PR body short but correct.
 


### PR DESCRIPTION
## Summary
- Phase 3 du skill `implement-github-issue` renommée *Plan internally* : le plan reste interne (mental ou via `TodoWrite`) au lieu d'être systématiquement soumis pour validation. L'agent enchaîne directement Phase 1 (lecture issue) → Phase 2 (lecture code) → Phase 4 (branche) → Phase 5 (implémentation).
- Filet de sécurité conservé pour les vraies ambiguïtés : critères contradictoires, scope clairement plus large que l'issue, décisions irréversibles (migration, breaking change, suppression de comportement).
- `references/workflow.md` ajusté en cohérence : pour les tickets triviaux, on saute désormais même la planification interne (avant on sautait *l'approbation* qui n'existe plus).

## Test plan
- [ ] Sur un futur ticket non-trivial, vérifier que le skill enchaîne lecture issue → lecture code → branche → implémentation, sans pause "voulez-vous que je continue ?".
- [ ] Sur un ticket délibérément ambigu (CA contradictoires ou scope flou), vérifier que le filet de sécurité se déclenche bien et que le skill demande clarification avant d'écrire du code.
- [ ] Sur un ticket trivial (typo, one-liner), vérifier qu'il va directement au fix sans même la phase de planification interne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)