### PR TITLE
#17 : refonte UI liste des activités (maquettes P2.1/P2.2)

### DIFF
--- a/activites/templates/activites/_activite_form.html
+++ b/activites/templates/activites/_activite_form.html
@@ -1,55 +1,50 @@
-<div class="card" id="activite-form-card">
-    <form method="post"
-          action="{% url 'activites:activite-create' %}"
-          hx-post="{% url 'activites:activite-create' %}"
-          hx-target="#activite-form-zone"
-          hx-swap="innerHTML"
-          novalidate>
-        {% csrf_token %}
+<form method="post"
+      action="{% url 'activites:activite-create' %}"
+      hx-post="{% url 'activites:activite-create' %}"
+      hx-target="#activite-form-zone"
+      hx-swap="innerHTML"
+      class="drawer-form"
+      novalidate>
+    {% csrf_token %}
 
-        {% if succes %}
-        <div class="success-banner" role="status" style="margin-bottom: 12px;">
-            {% include "partials/icons/_check.html" %}
-            <span>Activité ajoutée.</span>
+    <div class="field">
+        <label for="{{ form.titre.id_for_label }}" class="field-label">
+            {{ form.titre.label }}
+        </label>
+        {{ form.titre }}
+        {% if form.titre.errors %}
+        <div class="field-hint" style="color: var(--accent);">
+            {{ form.titre.errors|join:" " }}
         </div>
         {% endif %}
+    </div>
 
-        <div class="grid-2">
-            <div class="field">
-                <label for="{{ form.titre.id_for_label }}" class="field-label">
-                    {{ form.titre.label }}
-                </label>
-                {{ form.titre }}
-                {% if form.titre.errors %}
-                <div class="field-hint" style="color: var(--accent);">
-                    {{ form.titre.errors|join:" " }}
-                </div>
-                {% endif %}
-            </div>
-
-            <div class="field">
-                <label for="{{ form.categorie_nom.id_for_label }}" class="field-label">
-                    {{ form.categorie_nom.label }}
-                </label>
-                {{ form.categorie_nom }}
-                <datalist id="categories-existantes">
-                    {% for nom in categories_existantes %}
-                    <option value="{{ nom }}"></option>
-                    {% endfor %}
-                </datalist>
-                <div class="field-hint">
-                    Choisissez une catégorie existante ou tapez un nouveau nom.
-                </div>
-                {% if form.categorie_nom.errors %}
-                <div class="field-hint" style="color: var(--accent);">
-                    {{ form.categorie_nom.errors|join:" " }}
-                </div>
-                {% endif %}
-            </div>
+    <div class="field">
+        <label for="{{ form.categorie_nom.id_for_label }}" class="field-label">
+            {{ form.categorie_nom.label }}
+        </label>
+        {{ form.categorie_nom }}
+        <datalist id="categories-existantes">
+            {% for nom in categories_existantes %}
+            <option value="{{ nom }}"></option>
+            {% endfor %}
+        </datalist>
+        <div class="field-hint">
+            Choisissez une catégorie existante ou tapez un nouveau nom.
         </div>
-
-        <div class="btn-row end" style="margin-top: 12px;">
-            <button type="submit" class="btn btn-primary">Ajouter</button>
+        {% if form.categorie_nom.errors %}
+        <div class="field-hint" style="color: var(--accent);">
+            {{ form.categorie_nom.errors|join:" " }}
         </div>
-    </form>
-</div>
+        {% endif %}
+    </div>
+
+    <div class="btn-row end" style="margin-top: 16px;">
+        <button type="button"
+                class="btn btn-ghost"
+                data-drawer-close="ajouter-activite">
+            Annuler
+        </button>
+        <button type="submit" class="btn btn-primary">Ajouter</button>
+    </div>
+</form>

--- a/activites/templates/activites/_activites_liste.html
+++ b/activites/templates/activites/_activites_liste.html
@@ -8,25 +8,28 @@
      hx-trigger="activites-mises-a-jour from:body"
      hx-swap="outerHTML">
     {% if activites_par_categorie %}
-        {% for categorie, activites in activites_par_categorie.items %}
-        <div class="cat-head">{{ categorie.nom }}</div>
-        {% for activite in activites %}
-        <div class="card">
-            <div class="card-row">
-                <div class="card-grow">
-                    <div class="card-title">{{ activite.titre }}</div>
+        <div class="act-list">
+            {% for categorie, activites in activites_par_categorie.items %}
+            <div class="act-cat-head">
+                <span class="act-cat-name">{{ categorie.nom }}</span>
+                <span class="act-cat-count">{{ activites|length }}</span>
+            </div>
+            {% for activite in activites %}
+            <div class="act-row">
+                <div class="act-grow">
+                    <div class="act-title">{{ activite.titre }}</div>
                 </div>
             </div>
+            {% endfor %}
+            {% endfor %}
         </div>
-        {% endfor %}
-        {% endfor %}
     {% else %}
         <div class="empty">
             <div class="empty-illu" aria-hidden="true"></div>
             <div class="empty-title">Aucune activité pour le moment</div>
             <div class="empty-sub">
                 Ajoutez la première tâche commune à votre foyer
-                à l'aide du formulaire ci-dessus.
+                via le bouton « + Ajouter une activité ».
             </div>
         </div>
     {% endif %}

--- a/activites/templates/activites/liste.html
+++ b/activites/templates/activites/liste.html
@@ -21,17 +21,94 @@
                 <span id="activites-compteur">{{ nb_activites }} activité{{ nb_activites|pluralize }}</span>
             </p>
         </div>
+        <button type="button"
+                class="btn btn-primary"
+                data-drawer-open="ajouter-activite"
+                aria-haspopup="dialog"
+                aria-controls="drawer-ajouter-activite">
+            + Ajouter une activité
+        </button>
     </header>
 
-    <section style="margin-top: 8px;">
-        <div class="cat-head">Ajouter une activité</div>
-        <div id="activite-form-zone">
-            {% include "activites/_activite_form.html" %}
-        </div>
-    </section>
-
-    <section style="margin-top: 24px;">
+    <section style="margin-top: 16px;">
         {% include "activites/_activites_liste.html" %}
     </section>
 </div>
+
+<div class="drawer-overlay"
+     data-drawer-overlay="ajouter-activite"
+     hidden></div>
+
+<aside id="drawer-ajouter-activite"
+       class="drawer"
+       role="dialog"
+       aria-modal="true"
+       aria-labelledby="drawer-ajouter-activite-titre"
+       hidden>
+    <header class="drawer-head">
+        <div class="drawer-head-row">
+            <div>
+                <h2 id="drawer-ajouter-activite-titre" class="drawer-title">Nouvelle activité</h2>
+                <p class="drawer-sub">Ajoutez une tâche récurrente du foyer.</p>
+            </div>
+            <button type="button"
+                    class="btn btn-ghost btn-sm drawer-close"
+                    data-drawer-close="ajouter-activite"
+                    aria-label="Fermer">
+                ×
+            </button>
+        </div>
+    </header>
+    <div class="drawer-body" id="activite-form-zone">
+        {% include "activites/_activite_form.html" %}
+    </div>
+</aside>
+
+<script>
+(function () {
+    const drawerName = "ajouter-activite";
+    const drawer = document.getElementById("drawer-" + drawerName);
+    const overlay = document.querySelector('[data-drawer-overlay="' + drawerName + '"]');
+    const openBtns = document.querySelectorAll('[data-drawer-open="' + drawerName + '"]');
+    const closeBtns = document.querySelectorAll('[data-drawer-close="' + drawerName + '"]');
+
+    if (!drawer || !overlay) return;
+
+    function openDrawer() {
+        drawer.hidden = false;
+        overlay.hidden = false;
+        // Force reflow pour que la transition CSS s'applique.
+        void drawer.offsetWidth;
+        drawer.classList.add("is-open");
+        overlay.classList.add("is-open");
+        const firstInput = drawer.querySelector("input, textarea, select");
+        if (firstInput) firstInput.focus();
+    }
+
+    function closeDrawer() {
+        drawer.classList.remove("is-open");
+        overlay.classList.remove("is-open");
+        // Attend la fin de la transition avant de masquer pour l'a11y.
+        setTimeout(function () {
+            drawer.hidden = true;
+            overlay.hidden = true;
+        }, 200);
+    }
+
+    openBtns.forEach(function (btn) {
+        btn.addEventListener("click", openDrawer);
+    });
+    closeBtns.forEach(function (btn) {
+        btn.addEventListener("click", closeDrawer);
+    });
+    overlay.addEventListener("click", closeDrawer);
+
+    document.addEventListener("keydown", function (e) {
+        if (e.key === "Escape" && !drawer.hidden) closeDrawer();
+    });
+
+    // Fermeture automatique après création réussie d'une activité.
+    document.body.addEventListener("activites-mises-a-jour", closeDrawer);
+})();
+</script>
 {% endblock %}

--- a/activites/views.py
+++ b/activites/views.py
@@ -112,7 +112,6 @@ class ActiviteCreateView(_ActivitesFoyerMixin, View):
                             "nom", flat=True
                         )
                     ),
-                    "succes": True,
                 },
             )
             response["HX-Trigger"] = "activites-mises-a-jour"

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1128,6 +1128,110 @@ html.no-grid {
   letter-spacing: 0.04em;
 }
 
+/* ── Activity list (P2.1) ────────────── */
+.act-list {
+  border-top: 1px solid var(--line);
+}
+.act-cat-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 18px;
+  margin-bottom: 4px;
+  padding: 0 4px;
+}
+.act-list > .act-cat-head:first-child { margin-top: 12px; }
+.act-cat-name {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-weight: 500;
+}
+.act-cat-count {
+  font-size: 11px;
+  color: var(--muted);
+  opacity: 0.7;
+}
+.act-list .act-row {
+  grid-template-columns: 1fr;
+  gap: 4px;
+  padding: 14px 4px;
+}
+
+/* ── Drawer (right-side panel) ───────── */
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.18);
+  z-index: 90;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+.drawer-overlay.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 380px;
+  max-width: 92vw;
+  background: var(--bg);
+  border-left: 1px solid var(--line-strong);
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.06);
+  z-index: 100;
+  transform: translateX(100%);
+  transition: transform 0.2s ease;
+  display: flex;
+  flex-direction: column;
+}
+.drawer.is-open {
+  transform: translateX(0);
+}
+.drawer[hidden] { display: none; }
+.drawer-overlay[hidden] { display: none; }
+.drawer-head {
+  padding: 24px 24px 12px;
+  border-bottom: 1px solid var(--line);
+}
+.drawer-head-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+.drawer-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+.drawer-sub {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 4px 0 0;
+}
+.drawer-close {
+  font-size: 20px;
+  line-height: 1;
+  padding: 2px 8px;
+  color: var(--muted);
+}
+.drawer-body {
+  padding: 20px 24px 24px;
+  flex: 1;
+  overflow-y: auto;
+}
+.drawer-form .field input { width: 100%; }
+
+@media (max-width: 480px) {
+  .drawer { width: 100vw; max-width: 100vw; border-left: 0; }
+}
+
 /* ── Pending row in table (P3.2) ──────── */
 .tbl tr.row-pending td { background: rgba(193, 106, 77, 0.05); }
 .tbl tr.row-none td { opacity: 0.55; }


### PR DESCRIPTION
## Summary
Aligne la page **Activités** sur les maquettes P2.1 (liste) et P2.2 (drawer d'ajout).

- Le formulaire d'ajout n'est plus inline au-dessus de la liste : un bouton `+ Ajouter une activité` dans le header ouvre désormais un panneau latéral droit (drawer).
- Drawer fermable via *Annuler*, croix, `Échap` ou clic sur le backdrop ; se ferme automatiquement à la création réussie (sur l'évènement HTMX `activites-mises-a-jour`).
- Lignes de liste restylées (classe `.act-row` du DS) ; en-tête de catégorie enrichi (nom + compteur).
- Pas de changement back / API : on réutilise la route `activites:activite-create` existante et son `HX-Trigger`. Suppression du flag `succes` devenu inutile (drawer fermé à la création, le refresh de la liste sert de feedback).

Hors scope (issue #17) : filtres, métadonnées (PHYS./MENT., fréquence, durée), pastilles de statut, drag & drop.

Fixes #17

## Test plan
- [x] `ruff check .` ✅
- [x] `pytest --cov=activites` → 168 passed, couverture activites = 98.45%
- [x] Vérification manuelle (`docker compose run`) :
  - `GET /activites/` → bouton visible, drawer absent du DOM visible (`hidden`), lignes au nouveau style
  - `POST /activites/ajouter/` (HTMX) → 200 + `HX-Trigger: activites-mises-a-jour`, nouvelle activité présente dans `/activites/liste-fragment/`
- [ ] À vérifier en navigateur : ouverture/fermeture du drawer, focus initial sur le premier champ, fermeture sur `Échap` et clic backdrop, fermeture auto à la création réussie

🤖 Generated with [Claude Code](https://claude.com/claude-code)