### PR TITLE
US-302 (#20) : centrer le contenu des pilules `.rate-btn`

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -719,6 +719,11 @@ body { min-height: 100vh; }
   background: var(--bg);
   color: var(--ink);
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  text-align: center;
 }
 .rate-btn:hover { background: var(--paper); }
 .rate-btn.selected {


### PR DESCRIPTION
Sans cela, le texte se colle à gauche quand `.rate-btn` est rendu sur un `<label>` (le centrage venait implicitement du `<button>` d'origine). Ajoute `display: inline-flex` + `justify-content: center` + `text-align: center`, et `position: relative` pour contenir l'input radio en absolute.