### PR TITLE
Ajustements UX front : sidebar mobile, modal invitation, redirection éval

### DIFF
--- a/activites/templates/activites/liste.html
+++ b/activites/templates/activites/liste.html
@@ -22,11 +22,13 @@
             </p>
         </div>
         <button type="button"
-                class="btn btn-primary"
+                class="btn btn-primary btn-add"
                 data-drawer-open="ajouter-activite"
                 aria-haspopup="dialog"
-                aria-controls="drawer-ajouter-activite">
-            + Ajouter une activité
+                aria-controls="drawer-ajouter-activite"
+                aria-label="Ajouter une activité">
+            {% include "partials/icons/_plus.html" %}
+            <span class="btn-add-label">Ajouter une activité</span>
         </button>
     </header>
 

--- a/comptes/templates/comptes/login.html
+++ b/comptes/templates/comptes/login.html
@@ -9,16 +9,7 @@
         <span class="sb-brand-name">HomeSweetHome</span>
     </nav>
 
-    <div class="public-body">
-        <section class="public-left">
-            <div class="muted sm">HomeSweetHome</div>
-            <h1 class="hero-title">Une charge ménagère partagée, sans charge mentale.</h1>
-            <p class="hero-lead">
-                Connectez-vous pour retrouver votre foyer, suivre les activités du quotidien
-                et répartir équitablement la charge avec votre conjoint·e.
-            </p>
-        </section>
-
+    <div class="public-body public-body-solo">
         <section class="public-right">
             <div class="form-card">
                 <h2 class="form-title">Connexion</h2>

--- a/evaluations/templates/evaluations/_charge_dots.html
+++ b/evaluations/templates/evaluations/_charge_dots.html
@@ -1,7 +1,13 @@
-{# Affiche un score de charge 1→5 en dots verticaux (P3 du design system).
-   Args : libelle (str), valeur (int 1-5). #}
+{% comment %}
+Affiche un score de charge 1→5 en dots verticaux (P3 du design system).
+Args : libelle (str), valeur (int 1-5).
+
+Conçu pour vivre à l'intérieur d'un parent `.charges-grid` qui aligne les
+trois colonnes (libellé, dots, valeur numérique) sur plusieurs lignes via
+`display: contents` sur `.charge`.
+{% endcomment %}
 {% with valeur=valeur|default:0 %}
-<div class="charge {% if valeur <= 2 %}charge-low{% elif valeur == 3 %}charge-mid{% else %}charge-high{% endif %}" style="margin-top: 12px;">
+<div class="charge">
     <span class="charge-label">{{ libelle }}</span>
     <span class="charge-dots" aria-hidden="true">
         {% for i in "12345" %}

--- a/evaluations/templates/evaluations/evaluer.html
+++ b/evaluations/templates/evaluations/evaluer.html
@@ -15,10 +15,6 @@
 
     <header class="page-head">
         <div>
-            <p class="muted sm">
-                <a href="{% url 'activites:activite-liste' %}" class="muted">← Activités</a>
-                · {{ activite.categorie.nom }}
-            </p>
             <h1 class="page-title">{{ activite.titre }}</h1>
             <p class="muted">
                 Évaluez la charge de cette activité sur une échelle de 1 à 5.
@@ -36,9 +32,11 @@
                 {% endif %}
             </div>
             {% if autre_membre and evaluation_autre %}
-                {% include "evaluations/_charge_dots.html" with libelle="Charge mentale" valeur=evaluation_autre.charge_mentale %}
-                {% include "evaluations/_charge_dots.html" with libelle="Charge physique" valeur=evaluation_autre.charge_physique %}
-                {% include "evaluations/_charge_dots.html" with libelle="Durée" valeur=evaluation_autre.duree %}
+                <div class="charges-grid">
+                    {% include "evaluations/_charge_dots.html" with libelle="Charge mentale" valeur=evaluation_autre.charge_mentale %}
+                    {% include "evaluations/_charge_dots.html" with libelle="Charge physique" valeur=evaluation_autre.charge_physique %}
+                    {% include "evaluations/_charge_dots.html" with libelle="Durée" valeur=evaluation_autre.duree %}
+                </div>
             {% elif autre_membre %}
                 <p class="muted" style="margin-top: 12px;">Pas encore évalué.</p>
             {% else %}

--- a/evaluations/tests/test_views.py
+++ b/evaluations/tests/test_views.py
@@ -147,7 +147,7 @@ def test_post_cree_l_evaluation_redirect_fallback():
     assert evaluation.duree == 2
 
 
-def test_post_htmx_renvoie_fragment_avec_hx_trigger():
+def test_post_htmx_redirige_vers_la_liste_des_activites():
     membre = MembreFoyerFactory()
     activite = ActiviteFactory(foyer=membre.foyer)
     client = Client()
@@ -159,10 +159,9 @@ def test_post_htmx_renvoie_fragment_avec_hx_trigger():
         headers={"hx-request": "true"},
     )
 
-    assert response.status_code == 200
-    assert response["HX-Trigger"] == "evaluation-enregistree"
-    content = response.content.decode("utf-8")
-    assert "Évaluation enregistrée." in content
+    assert response.status_code == 204
+    assert response["HX-Redirect"] == reverse("activites:activite-liste")
+    assert Evaluation.objects.filter(user=membre.user, activite=activite).exists()
 
 
 def test_post_met_a_jour_l_evaluation_existante():

--- a/evaluations/views.py
+++ b/evaluations/views.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponseForbidden
+from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.generic import View
@@ -105,16 +105,13 @@ class EvaluationView(_FoyerRequiredMixin, View):
             duree=form.cleaned_data["duree"],
         )
 
-        if is_htmx:
-            # On renvoie le fragment avec un état "Enregistré" et on
-            # déclenche `evaluation-enregistree` pour qu'un retour à la
-            # liste reflète le nouveau label « Évaluée ».
-            contexte = _contexte_form(
-                request=request, activite=activite, form=form, succes=True
-            )
-            response = render(request, self.template_form, contexte)
-            response["HX-Trigger"] = "evaluation-enregistree"
-            return response
-
         messages.success(request, "Évaluation enregistrée.")
-        return redirect(reverse("activites:activite-liste"))
+        url_liste = reverse("activites:activite-liste")
+        if is_htmx:
+            # `HX-Redirect` demande à HTMX de naviguer côté client vers la
+            # liste : le message succès ajouté ci-dessus sera affiché au
+            # prochain rendu (il vit dans la session).
+            response = HttpResponse(status=204)
+            response["HX-Redirect"] = url_liste
+            return response
+        return redirect(url_liste)

--- a/foyer/templates/foyer/mon_foyer.html
+++ b/foyer/templates/foyer/mon_foyer.html
@@ -25,10 +25,15 @@
                 {% endif %}
             </p>
         </div>
-        <form method="post" action="{% url 'comptes:deconnexion' %}">
-            {% csrf_token %}
-            <button type="submit" class="btn btn-ghost btn-sm">Se déconnecter</button>
-        </form>
+        {% if est_createur %}
+        <button type="button"
+                class="btn btn-primary"
+                data-modal-open="inviter-membre"
+                aria-haspopup="dialog"
+                aria-controls="modal-inviter-membre">
+            + Inviter un membre
+        </button>
+        {% endif %}
     </header>
 
     <section>
@@ -73,13 +78,6 @@
         </div>
         {% endif %}
 
-        <section style="margin-top: 24px;">
-            <div class="cat-head">Inviter un membre</div>
-            <div id="invitation-form-zone">
-                {% include "foyer/_invitation_form.html" %}
-            </div>
-        </section>
-
         {% if membres|length >= 2 %}
         <a class="next-step" href="{% url 'activites:activite-liste' %}" style="display: block; text-decoration: none; color: inherit;">
             <div class="muted sm">Prochaine étape</div>
@@ -89,4 +87,68 @@
         {% endif %}
     {% endif %}
 </div>
+
+{% if est_createur %}
+<div class="app-modal-overlay"
+     data-modal-overlay="inviter-membre"
+     hidden>
+    <div id="modal-inviter-membre"
+         class="app-modal"
+         role="dialog"
+         aria-modal="true"
+         aria-label="Inviter un membre">
+        <button type="button"
+                class="app-modal-close"
+                data-modal-close="inviter-membre"
+                aria-label="Fermer">
+            {% include "partials/icons/_close.html" %}
+        </button>
+        <div class="app-modal-body" id="invitation-form-zone">
+            {% include "foyer/_invitation_form.html" %}
+        </div>
+    </div>
+</div>
+
+<script>
+(function () {
+    const modalName = "inviter-membre";
+    const overlay = document.querySelector('[data-modal-overlay="' + modalName + '"]');
+    const openBtns = document.querySelectorAll('[data-modal-open="' + modalName + '"]');
+    const closeBtns = document.querySelectorAll('[data-modal-close="' + modalName + '"]');
+
+    if (!overlay) return;
+
+    function openModal() {
+        overlay.hidden = false;
+        // Force reflow pour que la transition CSS s'applique.
+        void overlay.offsetWidth;
+        overlay.classList.add("is-open");
+        const firstInput = overlay.querySelector("input, textarea, select");
+        if (firstInput) firstInput.focus();
+    }
+
+    function closeModal() {
+        overlay.classList.remove("is-open");
+        // Attend la fin de la transition avant de masquer pour l'a11y.
+        setTimeout(function () {
+            overlay.hidden = true;
+        }, 150);
+    }
+
+    openBtns.forEach(function (btn) {
+        btn.addEventListener("click", openModal);
+    });
+    closeBtns.forEach(function (btn) {
+        btn.addEventListener("click", closeModal);
+    });
+    overlay.addEventListener("click", function (e) {
+        if (e.target === overlay) closeModal();
+    });
+
+    document.addEventListener("keydown", function (e) {
+        if (e.key === "Escape" && !overlay.hidden) closeModal();
+    });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -47,6 +47,7 @@ body { min-height: 100vh; }
   flex-direction: column;
   gap: 2px;
 }
+.app-shell .sb-nav { flex: 1 1 auto; }
 .app-shell .sb-item {
   cursor: pointer;
   text-decoration: none;
@@ -59,19 +60,80 @@ body { min-height: 100vh; }
 .app-shell .sb-main > .content-medium,
 .app-shell .sb-main > .content-narrow { margin: 0 auto; }
 
+/* Footer ancré en bas de la sidebar (déconnexion). */
+.sb-footer {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+.sb-logout-form { margin: 0; }
+.sb-logout {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--ink-2);
+  text-align: left;
+}
+
+/* Hamburger (mobile uniquement) — masqué par défaut. */
+.hamburger {
+  display: none;
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 80;
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--ink);
+  padding: 0;
+}
+.hamburger:hover { color: var(--accent); }
+
+/* Bouton de fermeture de la sidebar (mobile uniquement). */
+.sidebar-close {
+  display: none;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--ink);
+  padding: 0;
+}
+.sidebar-close:hover { color: var(--accent); }
+
 @media (max-width: 720px) {
   .app-shell { grid-template-columns: 1fr; }
+  .hamburger { display: inline-flex; }
   .app-shell .sidebar {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background: var(--bg);
     border-right: 0;
-    border-bottom: 1px solid var(--line);
-    flex-direction: row;
-    align-items: center;
-    gap: 12px;
-    overflow-x: auto;
+    border-bottom: 0;
+    padding: 56px 16px 16px;
+    overflow-y: auto;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
   }
-  .app-shell .sidebar .sb-brand { border-bottom: 0; padding: 4px 10px; margin: 0; }
-  .app-shell .sidebar .sb-section { display: none; }
-  .app-shell .sb-main { padding: 24px 20px; }
+  .app-shell .sidebar.is-open { transform: translateX(0); }
+  .app-shell .sidebar .sidebar-close { display: inline-flex; }
+  .app-shell .sb-main { padding: 64px 20px 24px; }
+  body.sidebar-open { overflow: hidden; }
 }
 
 /* ── Frame chrome (browser-window-lite per screen) ───── */
@@ -397,6 +459,12 @@ body { min-height: 100vh; }
 }
 .btn-row.end { justify-content: flex-end; }
 
+/* Bouton "ajouter" — texte sur desktop, icône seule sur mobile. */
+@media (max-width: 720px) {
+  .btn-add { padding: 8px; gap: 0; }
+  .btn-add .btn-add-label { display: none; }
+}
+
 /* ── Fields ───────────────────────────── */
 .field {
   display: flex;
@@ -479,6 +547,74 @@ body { min-height: 100vh; }
   padding: 24px;
   width: 480px;
   box-shadow: 0 12px 32px rgba(0,0,0,0.10);
+}
+
+/* ── App modal (centered, fullscreen overlay) ─── */
+.app-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 110;
+  background: rgba(0, 0, 0, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+.app-modal-overlay.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+.app-modal-overlay[hidden] { display: none; }
+.app-modal {
+  position: relative;
+  background: var(--bg);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  width: 480px;
+  max-width: 100%;
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.12);
+  transform: translateY(8px);
+  transition: transform 0.15s ease;
+  overflow: hidden;
+}
+.app-modal-overlay.is-open .app-modal { transform: translateY(0); }
+.app-modal-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 1;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--muted);
+  padding: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius);
+}
+.app-modal-close:hover { color: var(--ink); background: var(--paper); }
+.app-modal-body {
+  padding: 0;
+  overflow-y: auto;
+}
+/* La carte interne fait office de contenu — pas de cadre dans le cadre. */
+.app-modal-body .card {
+  border: 0;
+  border-radius: 0;
+  margin: 0;
+  padding: 18px 20px 20px;
+  background: transparent;
+}
+@media (max-width: 480px) {
+  .app-modal-overlay { padding: 0; align-items: stretch; }
+  .app-modal { max-height: 100vh; border-radius: 0; border: 0; }
 }
 
 /* ── Modal ─────────────────────────────── */
@@ -665,8 +801,20 @@ body { min-height: 100vh; }
 }
 
 /* ── Charge score ───────────────────────── */
+.charges-grid {
+  display: grid;
+  grid-template-columns: max-content max-content max-content;
+  column-gap: 12px;
+  row-gap: 8px;
+  align-items: center;
+  margin-top: 12px;
+}
+/* Aplatit `.charge` pour que ses 3 enfants alignent à travers les rangées
+   du parent `.charges-grid` (mêmes colonnes pour chaque critère). */
+.charges-grid .charge { display: contents; }
+
 .charge {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 8px;
   font-size: 12px;
@@ -682,9 +830,7 @@ body { min-height: 100vh; }
   background: var(--line-strong);
   border-radius: 1px;
 }
-.charge-low .charge-dot.on { background: var(--low); }
-.charge-mid .charge-dot.on { background: var(--mid); }
-.charge-high .charge-dot.on { background: var(--high); }
+.charge-dot.on { background: var(--accent); }
 .charge-num {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
   font-size: 11px;
@@ -986,6 +1132,11 @@ body { min-height: 100vh; }
   padding: 56px 56px 40px;
   align-items: start;
 }
+.public-body.public-body-solo {
+  grid-template-columns: 1fr;
+  max-width: 480px;
+  margin: 0 auto;
+}
 .hero-title {
   font-size: 32px;
   font-weight: 600;
@@ -1020,6 +1171,19 @@ body { min-height: 100vh; }
 }
 .rate-left { padding-right: 16px; border-right: 1px solid var(--line); }
 .rate-right { display: flex; flex-direction: column; gap: 18px; }
+
+@media (max-width: 720px) {
+  .rate-layout {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+  .rate-left {
+    padding-right: 0;
+    padding-bottom: 16px;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+}
 .progress {
   height: 4px;
   background: var(--line);

--- a/templates/app_base.html
+++ b/templates/app_base.html
@@ -2,20 +2,39 @@
 
 {% comment %}
 Layout app HomeSweetHome — sidebar fixe à gauche (logo + nom du foyer en haut,
-puis les sections de navigation issues du context processor `nav_items`).
+puis les sections de navigation issues du context processor `nav_items`,
+et un bouton de déconnexion ancré tout en bas).
+En mobile la sidebar est masquée et s'ouvre via le bouton hamburger ; elle
+recouvre alors tout l'écran et se referme via le bouton « X ».
 {% endcomment %}
 
 {% block content %}
 <a href="#main-content" class="skip-link">Aller au contenu principal</a>
 
+<button type="button"
+        class="hamburger"
+        data-sidebar-toggle="open"
+        aria-label="Ouvrir le menu"
+        aria-controls="app-sidebar"
+        aria-expanded="false">
+    {% include "partials/icons/_menu.html" %}
+</button>
+
 <div class="app-shell">
-    <aside class="sidebar" aria-label="Navigation principale">
+    <aside id="app-sidebar" class="sidebar" aria-label="Navigation principale">
+        <button type="button"
+                class="sidebar-close"
+                data-sidebar-toggle="close"
+                aria-label="Fermer le menu">
+            {% include "partials/icons/_close.html" %}
+        </button>
+
         <div class="sb-brand">
             <div class="sb-brand-mark" aria-hidden="true">HSH</div>
             <div class="sb-brand-name">{{ foyer_courant.nom|default:"HomeSweetHome" }}</div>
         </div>
 
-        <nav>
+        <nav class="sb-nav">
             <div class="sb-section" id="sb-section-foyer">Foyer</div>
             <ul class="sb-list" aria-labelledby="sb-section-foyer">
                 {% for item in nav_items %}
@@ -41,10 +60,52 @@ puis les sections de navigation issues du context processor `nav_items`).
                 {% endfor %}
             </ul>
         </nav>
+
+        {% if user.is_authenticated %}
+        <div class="sb-footer">
+            <form method="post" action="{% url 'comptes:deconnexion' %}" class="sb-logout-form">
+                {% csrf_token %}
+                <button type="submit" class="sb-item sb-logout">
+                    {% include "partials/icons/_logout.html" %}
+                    Se déconnecter
+                </button>
+            </form>
+        </div>
+        {% endif %}
     </aside>
 
     <main class="sb-main" id="main-content" tabindex="-1">
         {% block app_content %}{% endblock %}
     </main>
 </div>
+
+<script>
+(function () {
+    const sidebar = document.getElementById("app-sidebar");
+    const openBtn = document.querySelector('[data-sidebar-toggle="open"]');
+    const closeBtns = document.querySelectorAll('[data-sidebar-toggle="close"]');
+    if (!sidebar || !openBtn) return;
+
+    function openSidebar() {
+        sidebar.classList.add("is-open");
+        document.body.classList.add("sidebar-open");
+        openBtn.setAttribute("aria-expanded", "true");
+    }
+    function closeSidebar() {
+        sidebar.classList.remove("is-open");
+        document.body.classList.remove("sidebar-open");
+        openBtn.setAttribute("aria-expanded", "false");
+    }
+
+    openBtn.addEventListener("click", openSidebar);
+    closeBtns.forEach(function (btn) {
+        btn.addEventListener("click", closeSidebar);
+    });
+    document.addEventListener("keydown", function (e) {
+        if (e.key === "Escape" && sidebar.classList.contains("is-open")) {
+            closeSidebar();
+        }
+    });
+})();
+</script>
 {% endblock %}

--- a/templates/partials/icons/_close.html
+++ b/templates/partials/icons/_close.html
@@ -1,0 +1,6 @@
+{% comment %}Icone "close" (X) — fermeture de la sidebar mobile / modal.{% endcomment %}
+<svg width="{{ size|default:24 }}" height="{{ size|default:24 }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="1.5"
+     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M18 6L6 18M6 6l12 12"/>
+</svg>

--- a/templates/partials/icons/_logout.html
+++ b/templates/partials/icons/_logout.html
@@ -1,0 +1,8 @@
+{% comment %}Icone "logout" — bouton de déconnexion.{% endcomment %}
+<svg width="{{ size|default:16 }}" height="{{ size|default:16 }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="1.5"
+     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+    <path d="M16 17l5-5-5-5"/>
+    <path d="M21 12H9"/>
+</svg>

--- a/templates/partials/icons/_menu.html
+++ b/templates/partials/icons/_menu.html
@@ -1,0 +1,6 @@
+{% comment %}Icone "hamburger" — bouton d'ouverture de la sidebar mobile.{% endcomment %}
+<svg width="{{ size|default:24 }}" height="{{ size|default:24 }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="1.5"
+     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M4 6h16M4 12h16M4 18h16"/>
+</svg>

--- a/templates/partials/icons/_plus.html
+++ b/templates/partials/icons/_plus.html
@@ -1,0 +1,6 @@
+{% comment %}Icone "plus" (+) — ajout d'un élément.{% endcomment %}
+<svg width="{{ size|default:16 }}" height="{{ size|default:16 }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="2"
+     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M12 5v14M5 12h14"/>
+</svg>


### PR DESCRIPTION
## Summary

Lot d'ajustements UI/UX sur la base du front existant — pas de nouveau domaine métier, uniquement des correctifs visuels et de navigation suite à un test interactif.

### Changements visuels

- **Sidebar** : la déconnexion est ancrée tout en bas de la sidebar (au lieu d'occuper la page Membres). En mobile, la sidebar est masquée par défaut et s'ouvre via un bouton hamburger en overlay plein écran (fermeture via la croix ou `Escape`).
- **Page Membres** : le formulaire d'invitation passe en **modal centré** déclenché par un bouton « + Inviter un membre ». La croix de fermeture vit directement dans la carte du formulaire (plus de double titre ni de blanc autour).
- **Liste Activités** : sur mobile, le bouton « + Ajouter une activité » est réduit à un picto `+` pour libérer l'en-tête.
- **Écran d'évaluation** :
  - Les deux colonnes s'empilent en mobile
  - Suppression du fil d'Ariane « ← Activités · Catégorie »
  - Les évaluations du conjoint sont rendues en **grille 3 colonnes** (libellé / dots / valeur) — les dots remplis sont toujours en couleur accent
  - Correctif d'un commentaire `{# … #}` multi-ligne qui apparaissait en texte brut dans la page (Django ne supporte que les commentaires mono-ligne pour cette syntaxe)
- **Page Connexion** : suppression de la colonne marketing à gauche, le formulaire est centré sur 480 px max.

### Comportement

- Après enregistrement d'une évaluation → **redirection automatique vers la liste des activités** (`HX-Redirect` côté HTMX, redirect classique en fallback). Le test correspondant a été mis à jour.

### Nouveaux assets

- 4 partials d'icônes SVG : `_menu`, `_close`, `_plus`, `_logout`.

## Test plan

- [ ] **Desktop** : sidebar avec déconnexion en bas ; page Membres sans bouton déconnexion mais avec « + Inviter un membre » qui ouvre la modal ; clic en dehors / Escape / croix ferment la modal.
- [ ] **Mobile** (DevTools < 720 px) : hamburger en haut à gauche, sidebar overlay au clic ; bouton `+` rond à la place de « Ajouter une activité » ; deux colonnes empilées sur l'écran d'évaluation.
- [ ] **Évaluation** : enregistrer une évaluation depuis le formulaire → redirige bien vers `/activites/` avec un toast « Évaluation enregistrée. ».
- [ ] **Page Connexion** : `/connexion/` n'affiche plus que le formulaire centré.
- [ ] **Tests** : `pytest` (205 ok) + `ruff check .` (ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)