### PR TITLE
#24 : édition du titre et de la catégorie d'une activité

### DIFF
--- a/activites/services.py
+++ b/activites/services.py
@@ -42,6 +42,25 @@ def creer_activite(*, foyer: Foyer, titre: str, categorie_nom: str) -> Activite:
     )
 
 
+def mettre_a_jour_activite(
+    activite: Activite, *, titre: str, categorie_nom: str
+) -> Activite:
+    """Met à jour le titre et la catégorie d'une activité existante.
+
+    La catégorie cible est résolue/créée dans le foyer de l'activité,
+    avec la même normalisation que pour la création (cf.
+    `get_or_create_categorie`). Les évaluations liées à l'activité
+    restent intactes : on modifie uniquement deux champs sur la ligne.
+    """
+    categorie, _ = get_or_create_categorie(
+        foyer=activite.foyer, nom=categorie_nom
+    )
+    activite.titre = titre.strip()
+    activite.categorie = categorie
+    activite.save(update_fields=["titre", "categorie"])
+    return activite
+
+
 def lister_activites_par_categorie(
     foyer: Foyer,
     *,

--- a/activites/templates/activites/_activite_form.html
+++ b/activites/templates/activites/_activite_form.html
@@ -1,50 +1,67 @@
-<form method="post"
-      action="{% url 'activites:activite-create' %}"
-      hx-post="{% url 'activites:activite-create' %}"
-      hx-target="#activite-form-zone"
-      hx-swap="innerHTML"
-      class="drawer-form"
-      novalidate>
-    {% csrf_token %}
-
-    <div class="field">
-        <label for="{{ form.titre.id_for_label }}" class="field-label">
-            {{ form.titre.label }}
-        </label>
-        {{ form.titre }}
-        {% if form.titre.errors %}
-        <div class="field-hint" style="color: var(--accent);">
-            {{ form.titre.errors|join:" " }}
+<header class="drawer-head">
+    <div class="drawer-head-row">
+        <div>
+            <h2 id="drawer-ajouter-activite-titre" class="drawer-title">{{ drawer_title }}</h2>
+            <p class="drawer-sub">{{ drawer_sub }}</p>
         </div>
-        {% endif %}
-    </div>
-
-    <div class="field">
-        <label for="{{ form.categorie_nom.id_for_label }}" class="field-label">
-            {{ form.categorie_nom.label }}
-        </label>
-        {{ form.categorie_nom }}
-        <datalist id="categories-existantes">
-            {% for nom in categories_existantes %}
-            <option value="{{ nom }}"></option>
-            {% endfor %}
-        </datalist>
-        <div class="field-hint">
-            Choisissez une catégorie existante ou tapez un nouveau nom.
-        </div>
-        {% if form.categorie_nom.errors %}
-        <div class="field-hint" style="color: var(--accent);">
-            {{ form.categorie_nom.errors|join:" " }}
-        </div>
-        {% endif %}
-    </div>
-
-    <div class="btn-row end" style="margin-top: 16px;">
         <button type="button"
-                class="btn btn-ghost"
-                data-drawer-close="ajouter-activite">
-            Annuler
+                class="btn btn-ghost btn-sm drawer-close"
+                data-drawer-close="ajouter-activite"
+                aria-label="Fermer">
+            ×
         </button>
-        <button type="submit" class="btn btn-primary">Ajouter</button>
     </div>
-</form>
+</header>
+
+<div class="drawer-body">
+    <form method="post"
+          action="{{ form_action }}"
+          hx-post="{{ form_action }}"
+          hx-target="#activite-form-zone"
+          hx-swap="innerHTML"
+          class="drawer-form"
+          novalidate>
+        {% csrf_token %}
+
+        <div class="field">
+            <label for="{{ form.titre.id_for_label }}" class="field-label">
+                {{ form.titre.label }}
+            </label>
+            {{ form.titre }}
+            {% if form.titre.errors %}
+            <div class="field-hint" style="color: var(--accent);">
+                {{ form.titre.errors|join:" " }}
+            </div>
+            {% endif %}
+        </div>
+
+        <div class="field">
+            <label for="{{ form.categorie_nom.id_for_label }}" class="field-label">
+                {{ form.categorie_nom.label }}
+            </label>
+            {{ form.categorie_nom }}
+            <datalist id="categories-existantes">
+                {% for nom in categories_existantes %}
+                <option value="{{ nom }}"></option>
+                {% endfor %}
+            </datalist>
+            <div class="field-hint">
+                Choisissez une catégorie existante ou tapez un nouveau nom.
+            </div>
+            {% if form.categorie_nom.errors %}
+            <div class="field-hint" style="color: var(--accent);">
+                {{ form.categorie_nom.errors|join:" " }}
+            </div>
+            {% endif %}
+        </div>
+
+        <div class="btn-row end" style="margin-top: 16px;">
+            <button type="button"
+                    class="btn btn-ghost"
+                    data-drawer-close="ajouter-activite">
+                Annuler
+            </button>
+            <button type="submit" class="btn btn-primary">{{ submit_label }}</button>
+        </div>
+    </form>
+</div>

--- a/activites/templates/activites/_activites_liste.html
+++ b/activites/templates/activites/_activites_liste.html
@@ -15,17 +15,28 @@
                 <span class="act-cat-count">{{ activites|length }}</span>
             </div>
             {% for activite in activites %}
-            <a class="act-row act-row-link{% if not activite.evaluee_par_user %} act-row-pending{% endif %}"
-               href="{% url 'evaluations:activite-evaluer' activite_id=activite.pk %}">
-                <div class="act-grow">
-                    <div class="act-title">{{ activite.titre }}</div>
-                </div>
-                {% if activite.evaluee_par_user %}
-                <span class="ev-pill ev-done">Évaluée</span>
-                {% else %}
-                <span class="ev-pill ev-wait">À évaluer</span>
-                {% endif %}
-            </a>
+            <div class="act-row{% if not activite.evaluee_par_user %} act-row-pending{% endif %}">
+                <a class="act-row-link"
+                   href="{% url 'evaluations:activite-evaluer' activite_id=activite.pk %}">
+                    <div class="act-grow">
+                        <div class="act-title">{{ activite.titre }}</div>
+                    </div>
+                    {% if activite.evaluee_par_user %}
+                    <span class="ev-pill ev-done">Évaluée</span>
+                    {% else %}
+                    <span class="ev-pill ev-wait">À évaluer</span>
+                    {% endif %}
+                </a>
+                <button type="button"
+                        class="act-row-edit-btn"
+                        hx-get="{% url 'activites:activite-modifier' activite_id=activite.pk %}"
+                        hx-target="#activite-form-zone"
+                        hx-swap="innerHTML"
+                        data-drawer-open="ajouter-activite"
+                        aria-label="Modifier {{ activite.titre }}">
+                    {% include "partials/icons/_pencil.html" %}
+                </button>
+            </div>
             {% endfor %}
             {% endfor %}
         </div>

--- a/activites/templates/activites/liste.html
+++ b/activites/templates/activites/liste.html
@@ -47,21 +47,7 @@
        aria-modal="true"
        aria-labelledby="drawer-ajouter-activite-titre"
        hidden>
-    <header class="drawer-head">
-        <div class="drawer-head-row">
-            <div>
-                <h2 id="drawer-ajouter-activite-titre" class="drawer-title">Nouvelle activité</h2>
-                <p class="drawer-sub">Ajoutez une tâche récurrente du foyer.</p>
-            </div>
-            <button type="button"
-                    class="btn btn-ghost btn-sm drawer-close"
-                    data-drawer-close="ajouter-activite"
-                    aria-label="Fermer">
-                ×
-            </button>
-        </div>
-    </header>
-    <div class="drawer-body" id="activite-form-zone">
+    <div id="activite-form-zone">
         {% include "activites/_activite_form.html" %}
     </div>
 </aside>
@@ -71,8 +57,8 @@
     const drawerName = "ajouter-activite";
     const drawer = document.getElementById("drawer-" + drawerName);
     const overlay = document.querySelector('[data-drawer-overlay="' + drawerName + '"]');
-    const openBtns = document.querySelectorAll('[data-drawer-open="' + drawerName + '"]');
-    const closeBtns = document.querySelectorAll('[data-drawer-close="' + drawerName + '"]');
+    const formZone = document.getElementById("activite-form-zone");
+    const formResetUrl = "{% url 'activites:activite-create' %}";
 
     if (!drawer || !overlay) return;
 
@@ -87,6 +73,18 @@
         if (firstInput) firstInput.focus();
     }
 
+    function resetFormZone() {
+        // Recharge un fragment "création" frais : évite que la prochaine
+        // ouverture du drawer (via "+ Ajouter") n'affiche les valeurs de
+        // l'édition précédente, et garde le CSRF token à jour.
+        if (window.htmx && formZone) {
+            window.htmx.ajax("GET", formResetUrl, {
+                target: "#activite-form-zone",
+                swap: "innerHTML",
+            });
+        }
+    }
+
     function closeDrawer() {
         drawer.classList.remove("is-open");
         overlay.classList.remove("is-open");
@@ -94,14 +92,20 @@
         setTimeout(function () {
             drawer.hidden = true;
             overlay.hidden = true;
+            resetFormZone();
         }, 200);
     }
 
-    openBtns.forEach(function (btn) {
-        btn.addEventListener("click", openDrawer);
-    });
-    closeBtns.forEach(function (btn) {
-        btn.addEventListener("click", closeDrawer);
+    // Délégation : les boutons "+ Ajouter", crayon (édition) et fermeture
+    // peuvent être re-rendus par HTMX (form ré-injecté). On n'attache donc
+    // pas les listeners à des nœuds figés au chargement initial.
+    document.addEventListener("click", function (e) {
+        if (e.target.closest('[data-drawer-open="' + drawerName + '"]')) {
+            openDrawer();
+        }
+        if (e.target.closest('[data-drawer-close="' + drawerName + '"]')) {
+            closeDrawer();
+        }
     });
     overlay.addEventListener("click", closeDrawer);
 
@@ -109,7 +113,7 @@
         if (e.key === "Escape" && !drawer.hidden) closeDrawer();
     });
 
-    // Fermeture automatique après création réussie d'une activité.
+    // Fermeture automatique après création/édition réussie d'une activité.
     document.body.addEventListener("activites-mises-a-jour", closeDrawer);
 })();
 </script>

--- a/activites/tests/test_services.py
+++ b/activites/tests/test_services.py
@@ -3,6 +3,7 @@ from activites.services import (
     creer_activite,
     get_or_create_categorie,
     lister_activites_par_categorie,
+    mettre_a_jour_activite,
 )
 from activites.tests.factories import ActiviteFactory, CategorieFactory
 from foyer.tests.factories import FoyerFactory
@@ -71,6 +72,70 @@ def test_creer_activite_isole_les_foyers():
 
     assert Categorie.objects.filter(foyer=foyer_b).count() == 1
     assert Activite.objects.filter(foyer=foyer_a).count() == 0
+
+
+def test_mettre_a_jour_activite_change_titre_et_categorie():
+    foyer = FoyerFactory()
+    cuisine = CategorieFactory(foyer=foyer, nom="Cuisine")
+    activite = ActiviteFactory(
+        foyer=foyer, categorie=cuisine, titre="Faire la vaisselle"
+    )
+
+    mettre_a_jour_activite(
+        activite, titre="Vider le lave-vaisselle", categorie_nom="Rangement"
+    )
+
+    activite.refresh_from_db()
+    assert activite.titre == "Vider le lave-vaisselle"
+    assert activite.categorie.nom == "Rangement"
+    # Nouvelle catégorie créée dans le foyer.
+    assert Categorie.objects.filter(foyer=foyer, nom="Rangement").exists()
+
+
+def test_mettre_a_jour_activite_reutilise_categorie_existante():
+    foyer = FoyerFactory()
+    cuisine = CategorieFactory(foyer=foyer, nom="Cuisine")
+    rangement = CategorieFactory(foyer=foyer, nom="Rangement")
+    activite = ActiviteFactory(foyer=foyer, categorie=cuisine, titre="X")
+
+    # Casse différente : doit retomber sur la catégorie existante.
+    mettre_a_jour_activite(activite, titre="X", categorie_nom="rangement")
+
+    activite.refresh_from_db()
+    assert activite.categorie_id == rangement.pk
+    assert Categorie.objects.filter(foyer=foyer).count() == 2
+
+
+def test_mettre_a_jour_activite_normalise_le_titre():
+    foyer = FoyerFactory()
+    activite = ActiviteFactory(foyer=foyer)
+
+    mettre_a_jour_activite(
+        activite, titre="  Sortir les poubelles  ", categorie_nom="Maison"
+    )
+
+    activite.refresh_from_db()
+    assert activite.titre == "Sortir les poubelles"
+
+
+def test_mettre_a_jour_activite_preserve_les_evaluations():
+    from comptes.tests.factories import UserFactory
+    from evaluations.models import Evaluation
+    from evaluations.tests.factories import EvaluationFactory
+
+    foyer = FoyerFactory()
+    user = UserFactory()
+    activite = ActiviteFactory(foyer=foyer, titre="Avant")
+    evaluation = EvaluationFactory(user=user, activite=activite)
+
+    mettre_a_jour_activite(
+        activite, titre="Après", categorie_nom="Nouvelle catégorie"
+    )
+
+    # L'évaluation pointe toujours sur la même ligne, intacte.
+    assert Evaluation.objects.filter(pk=evaluation.pk).exists()
+    evaluation.refresh_from_db()
+    assert evaluation.activite_id == activite.pk
 
 
 def test_lister_activites_par_categorie_groupe_et_trie():

--- a/activites/tests/test_urls.py
+++ b/activites/tests/test_urls.py
@@ -9,6 +9,13 @@ def test_activite_create_url_resolves():
     assert reverse("activites:activite-create") == "/activites/ajouter/"
 
 
+def test_activite_modifier_url_resolves():
+    assert (
+        reverse("activites:activite-modifier", kwargs={"activite_id": 42})
+        == "/activites/42/modifier/"
+    )
+
+
 def test_activite_liste_fragment_url_resolves():
     assert (
         reverse("activites:activite-liste-fragment")

--- a/activites/tests/test_views.py
+++ b/activites/tests/test_views.py
@@ -64,6 +64,22 @@ def test_liste_n_affiche_pas_les_activites_d_un_autre_foyer():
     assert "Tâche d'un autre foyer" not in response.content.decode("utf-8")
 
 
+def test_liste_affiche_un_bouton_crayon_par_activite():
+    membre = MembreFoyerFactory()
+    activite = ActiviteFactory(foyer=membre.foyer, titre="Vaisselle")
+
+    client = Client()
+    client.force_login(membre.user)
+    response = client.get(reverse("activites:activite-liste"))
+
+    content = response.content.decode("utf-8")
+    expected_url = reverse(
+        "activites:activite-modifier", kwargs={"activite_id": activite.pk}
+    )
+    assert 'hx-get="' + expected_url + '"' in content
+    assert 'aria-label="Modifier Vaisselle"' in content
+
+
 def test_liste_propose_les_categories_existantes_dans_le_datalist():
     membre = MembreFoyerFactory()
     CategorieFactory(foyer=membre.foyer, nom="Cuisine")
@@ -82,7 +98,7 @@ def test_liste_propose_les_categories_existantes_dans_le_datalist():
 # ---------------------------------------------------------------------------
 
 
-def test_create_get_redirige_vers_la_liste():
+def test_create_get_non_htmx_redirige_vers_la_liste():
     user = UserFactory()
     client = Client()
     client.force_login(user)
@@ -91,6 +107,25 @@ def test_create_get_redirige_vers_la_liste():
 
     assert response.status_code == 302
     assert response.url == reverse("activites:activite-liste")
+
+
+def test_create_get_htmx_renvoie_le_form_de_creation():
+    """GET HTMX → fragment "création" frais (utilisé pour réinitialiser
+    le drawer après édition)."""
+    membre = MembreFoyerFactory()
+    client = Client()
+    client.force_login(membre.user)
+
+    response = client.get(
+        reverse("activites:activite-create"),
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert 'action="' + reverse("activites:activite-create") + '"' in content
+    assert "Nouvelle activité" in content
+    assert "Ajouter" in content
 
 
 def test_create_post_non_htmx_cree_et_redirige():
@@ -179,6 +214,180 @@ def test_create_anonymous_redirects_to_login():
 
     assert response.status_code == 302
     assert reverse("comptes:connexion") in response.url
+
+
+# ---------------------------------------------------------------------------
+# ActiviteUpdateView
+# ---------------------------------------------------------------------------
+
+
+def test_update_anonymous_redirects_to_login():
+    client = Client()
+    response = client.get(
+        reverse("activites:activite-modifier", kwargs={"activite_id": 1})
+    )
+
+    assert response.status_code == 302
+    assert reverse("comptes:connexion") in response.url
+
+
+def test_update_get_non_htmx_redirige_vers_la_liste():
+    membre = MembreFoyerFactory()
+    activite = ActiviteFactory(foyer=membre.foyer)
+
+    client = Client()
+    client.force_login(membre.user)
+    response = client.get(
+        reverse("activites:activite-modifier", kwargs={"activite_id": activite.pk})
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse("activites:activite-liste")
+
+
+def test_update_get_htmx_renvoie_le_form_prerempli():
+    membre = MembreFoyerFactory()
+    cuisine = CategorieFactory(foyer=membre.foyer, nom="Cuisine")
+    activite = ActiviteFactory(
+        foyer=membre.foyer, categorie=cuisine, titre="Faire la vaisselle"
+    )
+
+    client = Client()
+    client.force_login(membre.user)
+    response = client.get(
+        reverse("activites:activite-modifier", kwargs={"activite_id": activite.pk}),
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert 'value="Faire la vaisselle"' in content
+    assert 'value="Cuisine"' in content
+    # L'apostrophe est échappée par Django (`&#x27;`) — d'où le match en deux temps.
+    assert "Modifier" in content and "activité" in content
+    assert "Enregistrer" in content
+    expected_action = reverse(
+        "activites:activite-modifier", kwargs={"activite_id": activite.pk}
+    )
+    assert 'action="' + expected_action + '"' in content
+
+
+def test_update_get_pour_activite_d_un_autre_foyer_renvoie_404():
+    membre = MembreFoyerFactory()
+    autre_membre = MembreFoyerFactory()
+    activite_autre = ActiviteFactory(foyer=autre_membre.foyer)
+
+    client = Client()
+    client.force_login(membre.user)
+    response = client.get(
+        reverse(
+            "activites:activite-modifier", kwargs={"activite_id": activite_autre.pk}
+        ),
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 404
+
+
+def test_update_post_htmx_modifie_l_activite():
+    membre = MembreFoyerFactory()
+    cuisine = CategorieFactory(foyer=membre.foyer, nom="Cuisine")
+    activite = ActiviteFactory(
+        foyer=membre.foyer, categorie=cuisine, titre="Vaisselle"
+    )
+
+    client = Client()
+    client.force_login(membre.user)
+    response = client.post(
+        reverse("activites:activite-modifier", kwargs={"activite_id": activite.pk}),
+        {"titre": "Vider le lave-vaisselle", "categorie_nom": "Rangement"},
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    assert response["HX-Trigger"] == "activites-mises-a-jour"
+    activite.refresh_from_db()
+    assert activite.titre == "Vider le lave-vaisselle"
+    assert activite.categorie.nom == "Rangement"
+    # Toujours une seule activité dans le foyer (pas de double).
+    assert Activite.objects.filter(foyer=membre.foyer).count() == 1
+
+
+def test_update_post_pour_activite_d_un_autre_foyer_renvoie_404():
+    membre = MembreFoyerFactory()
+    autre_membre = MembreFoyerFactory()
+    activite_autre = ActiviteFactory(
+        foyer=autre_membre.foyer, titre="Original"
+    )
+
+    client = Client()
+    client.force_login(membre.user)
+    response = client.post(
+        reverse(
+            "activites:activite-modifier", kwargs={"activite_id": activite_autre.pk}
+        ),
+        {"titre": "Hijack", "categorie_nom": "X"},
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 404
+    activite_autre.refresh_from_db()
+    assert activite_autre.titre == "Original"
+
+
+def test_update_post_htmx_avec_titre_vide_renvoie_400():
+    membre = MembreFoyerFactory()
+    activite = ActiviteFactory(foyer=membre.foyer, titre="Avant")
+
+    client = Client()
+    client.force_login(membre.user)
+    response = client.post(
+        reverse("activites:activite-modifier", kwargs={"activite_id": activite.pk}),
+        {"titre": "  ", "categorie_nom": "Cuisine"},
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 400
+    assert "HX-Trigger" not in response
+    activite.refresh_from_db()
+    assert activite.titre == "Avant"
+
+
+def test_update_post_preserve_les_evaluations():
+    from evaluations.models import Evaluation
+    from evaluations.tests.factories import EvaluationFactory
+
+    membre = MembreFoyerFactory()
+    activite = ActiviteFactory(foyer=membre.foyer, titre="Avant")
+    evaluation = EvaluationFactory(user=membre.user, activite=activite)
+
+    client = Client()
+    client.force_login(membre.user)
+    response = client.post(
+        reverse("activites:activite-modifier", kwargs={"activite_id": activite.pk}),
+        {"titre": "Après", "categorie_nom": "Nouvelle catégorie"},
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    assert Evaluation.objects.filter(pk=evaluation.pk).exists()
+
+
+def test_update_post_non_htmx_modifie_et_redirige():
+    membre = MembreFoyerFactory()
+    activite = ActiviteFactory(foyer=membre.foyer, titre="Avant")
+
+    client = Client()
+    client.force_login(membre.user)
+    response = client.post(
+        reverse("activites:activite-modifier", kwargs={"activite_id": activite.pk}),
+        {"titre": "Après", "categorie_nom": "Cuisine"},
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse("activites:activite-liste")
+    activite.refresh_from_db()
+    assert activite.titre == "Après"
 
 
 # ---------------------------------------------------------------------------

--- a/activites/urls.py
+++ b/activites/urls.py
@@ -12,6 +12,11 @@ urlpatterns = [
         name="activite-create",
     ),
     path(
+        "<int:activite_id>/modifier/",
+        views.ActiviteUpdateView.as_view(),
+        name="activite-modifier",
+    ),
+    path(
         "liste-fragment/",
         views.ActivitesListeFragmentView.as_view(),
         name="activite-liste-fragment",

--- a/activites/views.py
+++ b/activites/views.py
@@ -1,14 +1,19 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponseForbidden
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.generic import TemplateView, View
 
 from foyer.models import MembreFoyer
 
 from .forms import ActiviteCreationForm
-from .services import creer_activite, lister_activites_par_categorie
+from .models import Activite
+from .services import (
+    creer_activite,
+    lister_activites_par_categorie,
+    mettre_a_jour_activite,
+)
 
 
 def _foyer_du_user(user):
@@ -60,13 +65,46 @@ def _contexte_liste(foyer, *, user=None):
     }
 
 
+def _contexte_form(foyer, form, *, activite=None):
+    """Contexte rendu par `_activite_form.html`, pour création ou édition.
+
+    Quand `activite` est None on est en création : action vers
+    `activite-create`, libellé « Ajouter ». Sinon on cible la vue de
+    modification de cette activité, avec le libellé « Enregistrer ».
+    """
+    if activite is None:
+        form_action = reverse("activites:activite-create")
+        submit_label = "Ajouter"
+        drawer_title = "Nouvelle activité"
+        drawer_sub = "Ajoutez une tâche récurrente du foyer."
+    else:
+        form_action = reverse(
+            "activites:activite-modifier",
+            kwargs={"activite_id": activite.pk},
+        )
+        submit_label = "Enregistrer"
+        drawer_title = "Modifier l'activité"
+        drawer_sub = "Modifiez le titre ou la catégorie."
+    return {
+        "form": form,
+        "categories_existantes": list(
+            foyer.categories.order_by("nom").values_list("nom", flat=True)
+        ),
+        "form_action": form_action,
+        "submit_label": submit_label,
+        "drawer_title": drawer_title,
+        "drawer_sub": drawer_sub,
+    }
+
+
 class ActivitesListView(_ActivitesFoyerMixin, TemplateView):
     template_name = "activites/liste.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update(_contexte_liste(self.request.foyer, user=self.request.user))
-        context["form"] = ActiviteCreationForm()
+        # Le drawer initial est en mode "création".
+        context.update(_contexte_form(self.request.foyer, ActiviteCreationForm()))
         context["active_nav"] = "activites"
         return context
 
@@ -75,6 +113,15 @@ class ActiviteCreateView(_ActivitesFoyerMixin, View):
     template_form = "activites/_activite_form.html"
 
     def get(self, request):
+        # Sur GET HTMX (ex. réinitialisation du drawer après une édition),
+        # on renvoie un fragment "création" frais. Hors HTMX, on garde le
+        # comportement existant (redirect vers la liste).
+        if request.headers.get("HX-Request") == "true":
+            return render(
+                request,
+                self.template_form,
+                _contexte_form(request.foyer, ActiviteCreationForm()),
+            )
         return redirect("activites:activite-liste")
 
     def post(self, request):
@@ -86,18 +133,11 @@ class ActiviteCreateView(_ActivitesFoyerMixin, View):
                 return render(
                     request,
                     self.template_form,
-                    {
-                        "form": form,
-                        "categories_existantes": list(
-                            request.foyer.categories.order_by("nom").values_list(
-                                "nom", flat=True
-                            )
-                        ),
-                    },
+                    _contexte_form(request.foyer, form),
                     status=400,
                 )
             context = _contexte_liste(request.foyer, user=request.user)
-            context["form"] = form
+            context.update(_contexte_form(request.foyer, form))
             context["active_nav"] = "activites"
             return render(request, "activites/liste.html", context, status=400)
 
@@ -111,19 +151,79 @@ class ActiviteCreateView(_ActivitesFoyerMixin, View):
             response = render(
                 request,
                 self.template_form,
-                {
-                    "form": ActiviteCreationForm(),
-                    "categories_existantes": list(
-                        request.foyer.categories.order_by("nom").values_list(
-                            "nom", flat=True
-                        )
-                    ),
-                },
+                _contexte_form(request.foyer, ActiviteCreationForm()),
             )
             response["HX-Trigger"] = "activites-mises-a-jour"
             return response
 
         messages.success(request, "Activité ajoutée.")
+        return redirect(reverse("activites:activite-liste"))
+
+
+class ActiviteUpdateView(_ActivitesFoyerMixin, View):
+    template_form = "activites/_activite_form.html"
+
+    def _activite_du_foyer(self, request, activite_id):
+        # Filtre par foyer : 404 transparente si l'activité n'existe pas
+        # ou appartient à un autre foyer (évite de leaker l'existence).
+        return get_object_or_404(
+            Activite, pk=activite_id, foyer=request.foyer
+        )
+
+    def get(self, request, activite_id):
+        activite = self._activite_du_foyer(request, activite_id)
+        if request.headers.get("HX-Request") != "true":
+            return redirect("activites:activite-liste")
+        form = ActiviteCreationForm(
+            initial={
+                "titre": activite.titre,
+                "categorie_nom": activite.categorie.nom,
+            }
+        )
+        return render(
+            request,
+            self.template_form,
+            _contexte_form(request.foyer, form, activite=activite),
+        )
+
+    def post(self, request, activite_id):
+        activite = self._activite_du_foyer(request, activite_id)
+        form = ActiviteCreationForm(request.POST)
+        is_htmx = request.headers.get("HX-Request") == "true"
+
+        if not form.is_valid():
+            if is_htmx:
+                return render(
+                    request,
+                    self.template_form,
+                    _contexte_form(request.foyer, form, activite=activite),
+                    status=400,
+                )
+            context = _contexte_liste(request.foyer, user=request.user)
+            context.update(
+                _contexte_form(request.foyer, form, activite=activite)
+            )
+            context["active_nav"] = "activites"
+            return render(request, "activites/liste.html", context, status=400)
+
+        mettre_a_jour_activite(
+            activite,
+            titre=form.cleaned_data["titre"],
+            categorie_nom=form.cleaned_data["categorie_nom"],
+        )
+
+        if is_htmx:
+            # Réponse en mode "création" pour réinitialiser le drawer
+            # avant sa fermeture (HX-Trigger).
+            response = render(
+                request,
+                self.template_form,
+                _contexte_form(request.foyer, ActiviteCreationForm()),
+            )
+            response["HX-Trigger"] = "activites-mises-a-jour"
+            return response
+
+        messages.success(request, "Activité modifiée.")
         return redirect(reverse("activites:activite-liste"))
 
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1323,11 +1323,20 @@ html.no-grid {
   opacity: 0.7;
 }
 .act-list .act-row {
-  grid-template-columns: 1fr auto;
-  gap: 12px;
-  padding: 14px 4px;
+  display: flex;
+  align-items: stretch;
+  grid-template-columns: none;
+  gap: 0;
+  padding: 0;
 }
 .act-row-link {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 4px;
   text-decoration: none;
   color: inherit;
   cursor: pointer;
@@ -1335,8 +1344,28 @@ html.no-grid {
 .act-row-link:hover { background: var(--paper); }
 .act-row-link:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: -2px;
   border-radius: var(--radius);
+}
+.act-row-edit-btn {
+  flex: 0 0 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  border-radius: var(--radius);
+}
+.act-row-edit-btn:hover {
+  color: var(--ink);
+  background: var(--paper);
+}
+.act-row-edit-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 /* ── Drawer (right-side panel) ───────── */

--- a/templates/partials/icons/_pencil.html
+++ b/templates/partials/icons/_pencil.html
@@ -1,0 +1,7 @@
+{% comment %}Icone "crayon" — édition d'un élément.{% endcomment %}
+<svg width="{{ size|default:16 }}" height="{{ size|default:16 }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="2"
+     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M12 20h9"/>
+    <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/>
+</svg>


### PR DESCRIPTION
## Summary
- Icône crayon par activité dans la liste : ouvre le drawer existant avec le formulaire pré-rempli (titre + catégorie).
- Soumission → mise à jour sur place via une nouvelle vue `ActiviteUpdateView` + service `mettre_a_jour_activite`. Les évaluations liées restent intactes.
- `_activite_form.html` factorisé pour les modes création/édition ; drawer-head intégré au fragment swappable et JS basculé en délégation pour gérer les boutons re-rendus par HTMX. Reset du form sur fermeture (CSRF frais, pas de fuite des valeurs de la dernière édition).

Fixes #24

## Test plan
- [x] `docker compose exec web ruff check .`
- [x] `docker compose exec web pytest --cov=. --cov-report=term-missing` (221 passed, 95.97 % coverage)
- [x] Vérification manuelle (compte demo) :
  - [x] icône crayon présente sur chaque ligne, `aria-label="Modifier <titre>"`
  - [x] clic crayon → drawer ouvert, form pré-rempli, titre/catégorie corrects, libellé "Enregistrer"
  - [x] soumission → activité mise à jour, liste rafraîchie via HTMX, drawer fermé
  - [x] catégorie déplacée → activité visible sous la nouvelle section
  - [x] évaluation préexistante conservée (test unitaire dédié)
  - [x] activité d'un autre foyer → 404 (GET et POST)
  - [x] titre vide → 400, pas de `HX-Trigger`, drawer reste ouvert avec l'erreur
  - [x] clic sur le reste de la ligne navigue toujours vers l'écran d'évaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)