### PR TITLE
chore: ignorer les artefacts celerybeat-schedule*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ db.sqlite3-journal
 media/
 staticfiles/
 
+# Celery
+celerybeat-schedule*
+
 # Testing / coverage
 .coverage
 .coverage.*


### PR DESCRIPTION
## Summary
- Ajoute `celerybeat-schedule*` à `.gitignore` (nouvelle section `# Celery`)
- Évite que les artefacts runtime de Celery beat (`celerybeat-schedule`, `.db`, `-shm`, `-wal`) ne polluent `git status`

## Test plan
- [x] `git check-ignore -v` confirme que le pattern matche `celerybeat-schedule`, `.db`, `-shm`, `-wal`
- [x] `git status` revient propre après l'edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)