### PR TITLE
#29 : restaurer le scroll du drawer Activité quand le formulaire dépasse

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1441,6 +1441,17 @@ html.no-grid {
 }
 .drawer-form .field input { width: 100%; }
 
+/* Cible HTMX du drawer activités. Doit relayer la chaîne flex de `.drawer`
+   pour que `.drawer-body { flex:1; overflow-y:auto }` reprenne effet — sinon
+   le formulaire déborde silencieusement quand il dépasse la hauteur du
+   viewport (ex. mobile + 3 rate-blocks + bloc autre membre). */
+#activite-form-zone {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 @media (max-width: 480px) {
   .drawer { width: 100vw; max-width: 100vw; border-left: 0; }
 }


### PR DESCRIPTION
## Summary

Correctif CSS minimal pour la régression introduite par #27 : depuis que le drawer Activité contient les rate-blocks et le bloc « Évaluation de l'autre membre », son contenu peut dépasser la hauteur du viewport — et il ne scrollait pas, rendant les boutons Annuler / Enregistrer inaccessibles.

## Cause

Le wrapper `<div id="activite-form-zone">` (cible HTMX) s'intercale entre `.drawer` (flex column) et `.drawer-body { flex:1; overflow-y:auto }`, ce qui annule la chaîne flex : `.drawer-body` n'a plus de parent flex direct, donc plus de hauteur contrainte → débordement silencieux.

## Fix

Faire du wrapper un flex column lui-même :

```css
#activite-form-zone {
  flex: 1;
  min-height: 0;
  display: flex;
  flex-direction: column;
}
```

- `flex: 1` → le wrapper occupe toute la hauteur disponible dans `.drawer`.
- `min-height: 0` → autorise le shrink du body et donc le `overflow:auto`.
- `display: flex; flex-direction: column` → le `.drawer-body` retrouve un parent flex et son `flex:1` reprend effet.

Le wrapper reste pleinement utilisable comme cible HTMX (`hx-target="#activite-form-zone"` dans `_activite_form.html` et dans les boutons d'édition).

## Test plan

- [x] `ruff check .` clean
- [x] `pytest` : 217 tests OK (pas de régression)
- [ ] Smoke UI à valider :
  - [ ] Sur viewport ≤ 600 px : drawer scrolle, boutons accessibles, header reste visible en haut
  - [ ] Création (drawer minimal) : pas de régression visuelle
  - [ ] Édition avec autre membre évalué : scroll OK
  - [ ] Mobile portrait + paysage

Fixes #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ni7pXmAHxAW8Amqy1rUpRU)_